### PR TITLE
Store quantification as tsdf

### DIFF
--- a/docs/tutorials/gait_analysis.ipynb
+++ b/docs/tutorials/gait_analysis.ipynb
@@ -239,7 +239,7 @@
     "raw_data_segment_nr  = '0001' \n",
     "\n",
     "# Load the data from the file\n",
-    "df_imu, _, _ = load_tsdf_dataframe(path_to_prepared_data, prefix=f'IMU_segment{raw_data_segment_nr}')\n",
+    "df_imu, metadata_time, metadata_values = load_tsdf_dataframe(path_to_prepared_data, prefix=f'IMU_segment{raw_data_segment_nr}')\n",
     "\n",
     "df_imu"
    ]
@@ -836,6 +836,127 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Store as TSDF\n",
+    "The predicted probabilities (and optionally other features) can be stored and loaded in TSDF as demonstrated below. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tsdf\n",
+    "from paradigma.util import write_df_data\n",
+    "\n",
+    "# Set 'path_to_data' to the directory where you want to save the data\n",
+    "metadata_time_store = tsdf.TSDFMetadata(metadata_time.get_plain_tsdf_dict_copy(), path_to_data)\n",
+    "metadata_values_store = tsdf.TSDFMetadata(metadata_values.get_plain_tsdf_dict_copy(), path_to_data)\n",
+    "\n",
+    "# Select the columns to be saved \n",
+    "metadata_time_store.channels = ['time']\n",
+    "metadata_values_store.channels = ['pred_gait_proba']\n",
+    "\n",
+    "# Set the units\n",
+    "metadata_time_store.units = ['Relative seconds']\n",
+    "metadata_values_store.units = ['Probability']\n",
+    "metadata_time_store.data_type = float\n",
+    "metadata_values_store.data_type = float\n",
+    "\n",
+    "# Set the filenames\n",
+    "meta_store_filename = f'segment{raw_data_segment_nr}_meta.json'\n",
+    "values_store_filename = meta_store_filename.replace('_meta.json', '_values.bin')\n",
+    "time_store_filename = meta_store_filename.replace('_meta.json', '_time.bin')\n",
+    "\n",
+    "metadata_values_store.file_name = values_store_filename\n",
+    "metadata_time_store.file_name = time_store_filename\n",
+    "\n",
+    "write_df_data(metadata_time_store, metadata_values_store, path_to_data, meta_store_filename, df_gait)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>time</th>\n",
+       "      <th>pred_gait_proba</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000023</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.000024</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>0.000023</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.000023</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4.0</td>\n",
+       "      <td>0.000023</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   time  pred_gait_proba\n",
+       "0   0.0         0.000023\n",
+       "1   1.0         0.000024\n",
+       "2   2.0         0.000023\n",
+       "3   3.0         0.000023\n",
+       "4   4.0         0.000023"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_gait, _, _ = load_tsdf_dataframe(path_to_data, prefix=f'segment{raw_data_segment_nr}')\n",
+    "df_gait.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Once again, the `time` column indicates the start time of the window. Therefore, it can be observed that probabilities are predicted of overlapping windows, and not of individual timestamps. The function [`merge_timestamps_with_predictions`](https://github.com/biomarkersParkinson/paradigma/blob/main/src/paradigma/util.py) can be used to retrieve predicted probabilities per timestamp by aggregating the predicted probabilities of overlapping windows. This function is included in the next step."
    ]
   },
@@ -855,7 +976,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -885,7 +1006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -1118,7 +1239,7 @@
        "[5 rows x 62 columns]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1154,7 +1275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -1228,7 +1349,7 @@
        "4  1466.00                          0.033986"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1278,7 +1399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1306,7 +1427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -1319,22 +1440,158 @@
       "\n",
       "A total of 84 filtered gait segments have been quantified.\n",
       "\n",
-      "Gait segment metadata:\n"
+      "Metadata of the first gait segment:\n",
+      "{'duration_s': 9.0,\n",
+      " 'end_time_s': 2230.74,\n",
+      " 'segment_category': 'moderately_long',\n",
+      " 'start_time_s': 2221.75}\n",
+      "\n",
+      "Individual arm swings of the first gait segment of the filtered dataset:\n"
      ]
     },
     {
-     "ename": "AttributeError",
-     "evalue": "'dict' object has no attribute 'write'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mAttributeError\u001b[39m                            Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[9]\u001b[39m\u001b[32m, line 27\u001b[39m\n\u001b[32m     24\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mA total of \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mquantified_arm_swing[\u001b[33m'\u001b[39m\u001b[33msegment_nr\u001b[39m\u001b[33m'\u001b[39m].nunique()\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdataset_used\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m gait segments have been quantified.\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m     26\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mGait segment metadata:\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m---> \u001b[39m\u001b[32m27\u001b[39m \u001b[43mpprint\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43maggregated\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mgait_segment_meta\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mper_segment\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[32;43m1\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     29\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mThe first gait segment of the \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdataset_used\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m dataset, where each row corresponds to an individual arm swing:\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m     30\u001b[39m quantified_arm_swing.loc[quantified_arm_swing[\u001b[33m'\u001b[39m\u001b[33msegment_nr\u001b[39m\u001b[33m'\u001b[39m]==\u001b[32m1\u001b[39m]\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\pprint.py:55\u001b[39m, in \u001b[36mpprint\u001b[39m\u001b[34m(object, stream, indent, width, depth, compact, sort_dicts, underscore_numbers)\u001b[39m\n\u001b[32m     50\u001b[39m \u001b[38;5;250m\u001b[39m\u001b[33;03m\"\"\"Pretty-print a Python object to a stream [default is sys.stdout].\"\"\"\u001b[39;00m\n\u001b[32m     51\u001b[39m printer = PrettyPrinter(\n\u001b[32m     52\u001b[39m     stream=stream, indent=indent, width=width, depth=depth,\n\u001b[32m     53\u001b[39m     compact=compact, sort_dicts=sort_dicts,\n\u001b[32m     54\u001b[39m     underscore_numbers=underscore_numbers)\n\u001b[32m---> \u001b[39m\u001b[32m55\u001b[39m \u001b[43mprinter\u001b[49m\u001b[43m.\u001b[49m\u001b[43mpprint\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mobject\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\pprint.py:156\u001b[39m, in \u001b[36mPrettyPrinter.pprint\u001b[39m\u001b[34m(self, object)\u001b[39m\n\u001b[32m    154\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mpprint\u001b[39m(\u001b[38;5;28mself\u001b[39m, \u001b[38;5;28mobject\u001b[39m):\n\u001b[32m    155\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m._stream \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m156\u001b[39m         \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_format\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mobject\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_stream\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[32;43m0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[32;43m0\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m{\u001b[49m\u001b[43m}\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[32;43m0\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[32m    157\u001b[39m         \u001b[38;5;28mself\u001b[39m._stream.write(\u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\pprint.py:197\u001b[39m, in \u001b[36mPrettyPrinter._format\u001b[39m\u001b[34m(self, object, stream, indent, allowance, context, level)\u001b[39m\n\u001b[32m    195\u001b[39m         \u001b[38;5;28;01mdel\u001b[39;00m context[objid]\n\u001b[32m    196\u001b[39m         \u001b[38;5;28;01mreturn\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m197\u001b[39m \u001b[43mstream\u001b[49m\u001b[43m.\u001b[49m\u001b[43mwrite\u001b[49m(rep)\n",
-      "\u001b[31mAttributeError\u001b[39m: 'dict' object has no attribute 'write'"
-     ]
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>segment_nr</th>\n",
+       "      <th>segment_category</th>\n",
+       "      <th>range_of_motion</th>\n",
+       "      <th>peak_velocity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>moderately_long</td>\n",
+       "      <td>19.218491</td>\n",
+       "      <td>90.807689</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>moderately_long</td>\n",
+       "      <td>21.267287</td>\n",
+       "      <td>105.781357</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1</td>\n",
+       "      <td>moderately_long</td>\n",
+       "      <td>23.582098</td>\n",
+       "      <td>103.932332</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1</td>\n",
+       "      <td>moderately_long</td>\n",
+       "      <td>23.757712</td>\n",
+       "      <td>114.846304</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1</td>\n",
+       "      <td>moderately_long</td>\n",
+       "      <td>17.430734</td>\n",
+       "      <td>63.297391</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>1</td>\n",
+       "      <td>moderately_long</td>\n",
+       "      <td>12.139037</td>\n",
+       "      <td>59.740258</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>1</td>\n",
+       "      <td>moderately_long</td>\n",
+       "      <td>6.681346</td>\n",
+       "      <td>36.802784</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>1</td>\n",
+       "      <td>moderately_long</td>\n",
+       "      <td>6.293493</td>\n",
+       "      <td>30.793498</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>1</td>\n",
+       "      <td>moderately_long</td>\n",
+       "      <td>7.892546</td>\n",
+       "      <td>42.481470</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>1</td>\n",
+       "      <td>moderately_long</td>\n",
+       "      <td>9.633521</td>\n",
+       "      <td>43.837249</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>1</td>\n",
+       "      <td>moderately_long</td>\n",
+       "      <td>9.679263</td>\n",
+       "      <td>38.867993</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>1</td>\n",
+       "      <td>moderately_long</td>\n",
+       "      <td>9.437900</td>\n",
+       "      <td>34.112233</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>1</td>\n",
+       "      <td>moderately_long</td>\n",
+       "      <td>9.272199</td>\n",
+       "      <td>33.344802</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    segment_nr segment_category  range_of_motion  peak_velocity\n",
+       "0            1  moderately_long        19.218491      90.807689\n",
+       "1            1  moderately_long        21.267287     105.781357\n",
+       "2            1  moderately_long        23.582098     103.932332\n",
+       "3            1  moderately_long        23.757712     114.846304\n",
+       "4            1  moderately_long        17.430734      63.297391\n",
+       "5            1  moderately_long        12.139037      59.740258\n",
+       "6            1  moderately_long         6.681346      36.802784\n",
+       "7            1  moderately_long         6.293493      30.793498\n",
+       "8            1  moderately_long         7.892546      42.481470\n",
+       "9            1  moderately_long         9.633521      43.837249\n",
+       "10           1  moderately_long         9.679263      38.867993\n",
+       "11           1  moderately_long         9.437900      34.112233\n",
+       "12           1  moderately_long         9.272199      33.344802"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1363,10 +1620,10 @@
     "print(f\"Gait segments are created of minimum {config.min_segment_length_s} seconds and maximum {config.max_segment_gap_s} seconds gap between segments.\\n\")\n",
     "print(f\"A total of {quantified_arm_swing['segment_nr'].nunique()} {dataset_used} gait segments have been quantified.\")\n",
     "\n",
-    "print(f\"\\nGait segment metadata:\")\n",
-    "pprint(['aggregated'], gait_segment_meta['per_segment'][1])\n",
+    "print(f\"\\nMetadata of the first gait segment:\")\n",
+    "pprint(gait_segment_meta['per_segment'][1])\n",
     "\n",
-    "print(f\"\\nThe first gait segment of the {dataset_used} dataset, where each row corresponds to an individual arm swing:\")\n",
+    "print(f\"\\nIndividual arm swings of the first gait segment of the {dataset_used} dataset:\")\n",
     "quantified_arm_swing.loc[quantified_arm_swing['segment_nr']==1]"
    ]
   },
@@ -1399,7 +1656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1537,38 +1794,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'very_long': {'duration_s': 1905.75,\n",
-      "               'median_range_of_motion': 25.289651009660467,\n",
-      "               '95p_range_of_motion': 43.74907398039542,\n",
-      "               'median_peak_velocity': 125.9443142903539,\n",
-      "               '95p_peak_velocity': 217.80854223601995},\n",
-      " 'long': {'duration_s': 60.75,\n",
-      "          'median_range_of_motion': 15.781087457927843,\n",
-      "          '95p_range_of_motion': 45.16540046751928,\n",
-      "          'median_peak_velocity': 86.83257977334742,\n",
-      "          '95p_peak_velocity': 219.9725403489472},\n",
+      "{'long': {'duration_s': 60.75,\n",
+      "          'median_range_of_motion': 15.78108745792784,\n",
+      "          '95p_range_of_motion': 45.16540046751929,\n",
+      "          'median_peak_velocity': 86.83257977334745,\n",
+      "          '95p_peak_velocity': 219.97254034894718},\n",
       " 'short': {'duration_s': 153.75,\n",
-      "           'median_range_of_motion': 14.225382307390909,\n",
-      "           '95p_range_of_motion': 40.53847370093225,\n",
+      "           'median_range_of_motion': 14.225382307390944,\n",
+      "           '95p_range_of_motion': 40.53847370093226,\n",
       "           'median_peak_velocity': 71.56035976932178,\n",
       "           '95p_peak_velocity': 197.13328716416063},\n",
+      " 'very_long': {'duration_s': 1905.75,\n",
+      "               'median_range_of_motion': 25.2896510096605,\n",
+      "               '95p_range_of_motion': 43.74907398039543,\n",
+      "               'median_peak_velocity': 125.9443142903539,\n",
+      "               '95p_peak_velocity': 217.80854223601992},\n",
       " 'moderately_long': {'duration_s': 187.5,\n",
-      "                     'median_range_of_motion': 15.730045662205644,\n",
-      "                     '95p_range_of_motion': 54.558815671442936,\n",
+      "                     'median_range_of_motion': 15.73004566220565,\n",
+      "                     '95p_range_of_motion': 54.55881567144294,\n",
       "                     'median_peak_velocity': 77.94780939826387,\n",
-      "                     '95p_peak_velocity': 256.97997735460285},\n",
+      "                     '95p_peak_velocity': 256.9799773546029},\n",
       " 'all_segment_categories': {'duration_s': 2307.75,\n",
-      "                            'median_range_of_motion': 23.100608971051322,\n",
+      "                            'median_range_of_motion': 23.100608971051315,\n",
       "                            '95p_range_of_motion': 45.92600123148869,\n",
-      "                            'median_peak_velocity': 116.50364930684766,\n",
-      "                            '95p_peak_velocity': 219.20083578207513}}\n"
+      "                            'median_peak_velocity': 116.50364930684765,\n",
+      "                            '95p_peak_velocity': 219.2008357820751}}\n"
      ]
     }
    ],
@@ -1594,7 +1851,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "paradigma-cfWEGyqZ-py3.11",
+   "display_name": "paradigma-Fn6RLG4_-py3.11",
    "language": "python",
    "name": "python3"
   },
@@ -1608,7 +1865,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/gait_analysis.ipynb
+++ b/docs/tutorials/gait_analysis.ipynb
@@ -842,7 +842,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -859,7 +859,7 @@
     "\n",
     "# Set the units\n",
     "metadata_time_store.units = ['Relative seconds']\n",
-    "metadata_values_store.units = ['Probability']\n",
+    "metadata_values_store.units = ['Unitless']\n",
     "metadata_time_store.data_type = float\n",
     "metadata_values_store.data_type = float\n",
     "\n",

--- a/docs/tutorials/heart_rate_analysis.ipynb
+++ b/docs/tutorials/heart_rate_analysis.ipynb
@@ -297,11 +297,11 @@
     "\n",
     "segment_nr = '0001' \n",
     "\n",
-    "df_ppg, metadata_time_ppg, _ = load_tsdf_dataframe(\n",
+    "df_ppg, metadata_time_ppg, metadata_values_ppg = load_tsdf_dataframe(\n",
     "    path_to_data=path_to_prepared_data / ppg_prefix, \n",
     "    prefix=f'PPG_segment{segment_nr}'\n",
     ")\n",
-    "df_imu, metadata_time_imu, _ = load_tsdf_dataframe(\n",
+    "df_imu, metadata_time_imu, metadata_values_imu = load_tsdf_dataframe(\n",
     "    path_to_data=path_to_prepared_data / imu_prefix, \n",
     "    prefix=f'IMU_segment{segment_nr}'\n",
     ")\n",
@@ -734,7 +734,7 @@
        "      <td>4.0</td>\n",
        "      <td>7.393010e+04</td>\n",
        "      <td>218.379138</td>\n",
-       "      <td>187.583266</td>\n",
+       "      <td>187.583267</td>\n",
        "      <td>2.405921</td>\n",
        "      <td>0.084566</td>\n",
        "      <td>2.796140</td>\n",
@@ -845,7 +845,7 @@
        "1          1.0  1.102401e+05    271.582177    236.891936   2.251393 -0.029309   \n",
        "2          2.0  1.061479e+05    262.348604    225.915756   2.415221  0.216631   \n",
        "3          3.0  9.514719e+04    245.089445    203.417715   2.481465  0.110420   \n",
-       "4          4.0  7.393010e+04    218.379138    187.583266   2.405921  0.084566   \n",
+       "4          4.0  7.393010e+04    218.379138    187.583267   2.405921  0.084566   \n",
        "...        ...           ...           ...           ...        ...       ...   \n",
        "34329  34329.0  8.176078e+06   1613.021494    438.201240   6.122772 -1.792336   \n",
        "34330  34330.0  3.512188e+07   3307.888927   1069.775894   8.160698  1.746472   \n",
@@ -1070,6 +1070,133 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Store as TSDF\n",
+    "The predicted probabilities (and optionally other features) can be stored and loaded in TSDF as demonstrated below. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tsdf\n",
+    "from paradigma.util import write_df_data\n",
+    "\n",
+    "# Set 'path_to_data' to the directory where you want to save the data\n",
+    "metadata_time_store = tsdf.TSDFMetadata(metadata_time_ppg.get_plain_tsdf_dict_copy(), path_to_prepared_data)\n",
+    "metadata_values_store = tsdf.TSDFMetadata(metadata_values_ppg.get_plain_tsdf_dict_copy(), path_to_prepared_data)\n",
+    "\n",
+    "# Select the columns to be saved \n",
+    "metadata_time_store.channels = ['time']\n",
+    "metadata_values_store.channels = ['pred_sqa_proba', 'pred_sqa_acc_label']\n",
+    "\n",
+    "# Set the units\n",
+    "metadata_time_store.units = ['Relative seconds']\n",
+    "metadata_values_store.units = ['Unitless', 'Unitless']\n",
+    "metadata_time_store.data_type = float\n",
+    "metadata_values_store.data_type = float\n",
+    "\n",
+    "# Set the filenames\n",
+    "meta_store_filename = f'segment{segment_nr}_meta.json'\n",
+    "values_store_filename = meta_store_filename.replace('_meta.json', '_values.bin')\n",
+    "time_store_filename = meta_store_filename.replace('_meta.json', '_time.bin')\n",
+    "\n",
+    "metadata_values_store.file_name = values_store_filename\n",
+    "metadata_time_store.file_name = time_store_filename\n",
+    "\n",
+    "write_df_data(metadata_time_store, metadata_values_store, path_to_prepared_data, meta_store_filename, df_sqa)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>time</th>\n",
+       "      <th>pred_sqa_proba</th>\n",
+       "      <th>pred_sqa_acc_label</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.011213</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.007126</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>0.007018</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3.0</td>\n",
+       "      <td>0.004134</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4.0</td>\n",
+       "      <td>0.000920</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   time  pred_sqa_proba  pred_sqa_acc_label\n",
+       "0   0.0        0.011213                 1.0\n",
+       "1   1.0        0.007126                 1.0\n",
+       "2   2.0        0.007018                 1.0\n",
+       "3   3.0        0.004134                 1.0\n",
+       "4   4.0        0.000920                 1.0"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_sqa, _, _ = load_tsdf_dataframe(path_to_prepared_data, prefix=f'segment{segment_nr}')\n",
+    "df_sqa.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Step 4: Heart rate estimation"
    ]
   },
@@ -1084,7 +1211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -1197,7 +1324,7 @@
        "[830 rows x 2 columns]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1234,7 +1361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1260,7 +1387,7 @@
     "# Create a list of dataframes to store the estimated heart rates of all segments\n",
     "list_df_hr = []\n",
     "\n",
-    "segments = ['0001','0002'] # list with all available segments\n",
+    "segments = ['0001', '0002'] # list with all available segments\n",
     "\n",
     "for segment_nr in segments:\n",
     "    \n",
@@ -1342,7 +1469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -1371,7 +1498,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "paradigma-cfWEGyqZ-py3.11",
+   "display_name": "paradigma-Fn6RLG4_-py3.11",
    "language": "python",
    "name": "python3"
   },
@@ -1385,7 +1512,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/tremor_analysis.ipynb
+++ b/docs/tutorials/tremor_analysis.ipynb
@@ -238,7 +238,7 @@
     "\n",
     "segment_nr  = '0001' \n",
     "\n",
-    "df_data, metadata_time, _ = load_tsdf_dataframe(path_to_prepared_data, prefix=f'IMU_segment{segment_nr}')\n",
+    "df_data, metadata_time, metadata_values = load_tsdf_dataframe(path_to_prepared_data, prefix=f'IMU_segment{segment_nr}')\n",
     "\n",
     "df_data"
    ]
@@ -957,6 +957,152 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Store as TSDF\n",
+    "The predicted probabilities (and optionally other features) can be stored and loaded in TSDF as demonstrated below. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tsdf\n",
+    "from paradigma.util import write_df_data\n",
+    "\n",
+    "# Set 'path_to_data' to the directory where you want to save the data\n",
+    "metadata_time_store = tsdf.TSDFMetadata(metadata_time.get_plain_tsdf_dict_copy(), path_to_data)\n",
+    "metadata_values_store = tsdf.TSDFMetadata(metadata_values.get_plain_tsdf_dict_copy(), path_to_data)\n",
+    "\n",
+    "# Select the columns to be saved \n",
+    "metadata_time_store.channels = ['time']\n",
+    "metadata_values_store.channels = ['pred_tremor_proba', 'pred_tremor_logreg', 'pred_arm_at_rest', 'pred_tremor_checked']\n",
+    "\n",
+    "# Set the units\n",
+    "metadata_time_store.units = ['Relative seconds']\n",
+    "metadata_values_store.units = ['Probability', 'Boolean', 'Boolean', 'Boolean']\n",
+    "metadata_time_store.data_type = float\n",
+    "metadata_values_store.data_type = float\n",
+    "\n",
+    "# Set the filenames\n",
+    "meta_store_filename = f'segment{segment_nr}_meta.json'\n",
+    "values_store_filename = meta_store_filename.replace('_meta.json', '_values.bin')\n",
+    "time_store_filename = meta_store_filename.replace('_meta.json', '_time.bin')\n",
+    "\n",
+    "metadata_values_store.file_name = values_store_filename\n",
+    "metadata_time_store.file_name = time_store_filename\n",
+    "\n",
+    "write_df_data(metadata_time_store, metadata_values_store, path_to_data, meta_store_filename, df_predictions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>time</th>\n",
+       "      <th>pred_tremor_proba</th>\n",
+       "      <th>pred_tremor_logreg</th>\n",
+       "      <th>pred_arm_at_rest</th>\n",
+       "      <th>pred_tremor_checked</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.038968</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>4.0</td>\n",
+       "      <td>0.035365</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>8.0</td>\n",
+       "      <td>0.031255</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>12.0</td>\n",
+       "      <td>0.021106</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>16.0</td>\n",
+       "      <td>0.021078</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   time  pred_tremor_proba  pred_tremor_logreg  pred_arm_at_rest  \\\n",
+       "0   0.0           0.038968                 1.0               1.0   \n",
+       "1   4.0           0.035365                 1.0               1.0   \n",
+       "2   8.0           0.031255                 1.0               1.0   \n",
+       "3  12.0           0.021106                 0.0               1.0   \n",
+       "4  16.0           0.021078                 0.0               1.0   \n",
+       "\n",
+       "   pred_tremor_checked  \n",
+       "0                  1.0  \n",
+       "1                  1.0  \n",
+       "2                  0.0  \n",
+       "3                  0.0  \n",
+       "4                  0.0  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_predictions, _, _ = load_tsdf_dataframe(path_to_data, prefix=f'segment{segment_nr}')\n",
+    "df_predictions.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Run steps 1 - 3 for all segments <a id='multiple_segments_cell'></a>"
    ]
   },
@@ -969,7 +1115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1044,7 +1190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -1092,7 +1238,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "paradigma-cfWEGyqZ-py3.11",
+   "display_name": "paradigma-Fn6RLG4_-py3.11",
    "language": "python",
    "name": "python3"
   },
@@ -1106,7 +1252,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/tremor_analysis.ipynb
+++ b/docs/tutorials/tremor_analysis.ipynb
@@ -963,7 +963,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -980,7 +980,7 @@
     "\n",
     "# Set the units\n",
     "metadata_time_store.units = ['Relative seconds']\n",
-    "metadata_values_store.units = ['Probability', 'Boolean', 'Boolean', 'Boolean']\n",
+    "metadata_values_store.units = ['Unitless', 'Unitless', 'Unitless', 'Unitless']  \n",
     "metadata_time_store.data_type = float\n",
     "metadata_values_store.data_type = float\n",
     "\n",


### PR DESCRIPTION
## Description

See #163. The tutorials using example data only used TSDF for loading data, but not for storing. 

## Changes

I have added the option to store a time series dataframe in the domain tutorials: (1) gait, (2) tremor, and (3) heart rate. These have been added after the classification step (for gait after gait detection, such that a user can move it to detection of other arm activities if desired).

## Additional Information

We had to make a decision whether to store the classification and/or quantification step, but the quantification step for gait does not result in a time series. I therefore opted for providing example code for storing in TSDF format at the classification step.

## Checklist

- [X] Tests passed
- [X] Documentation updated
