### PR TITLE
Add word break to ensure width limit tables on gh pages

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -14,4 +14,5 @@ table.docutils {
     word-wrap: break-word;
     white-space: normal;
     overflow-wrap: break-word;
+    word-break: break-word;
   }


### PR DESCRIPTION
## Description

This does not solve an existing backlog issue, but it came to my awareness that long lines in tables on GH pages did not have word breaks or line breaks and therefore required readers to use extensive horizontal scrolling.

## Changes

Added a word break to the CSS configuration.
