### PR TITLE
Adding static pages for github pages to render

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,6 +28,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        lfs: true  # Enable Git LFS support
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -44,7 +46,7 @@ jobs:
         echo Version: $VERSION
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-    # Installation
+    # Install project dependencies
     - name: Install dependencies
       run: |
         python -m pip install poetry
@@ -52,27 +54,24 @@ jobs:
 
     # Testing and checking
     - name: Test with pytest
-      run: |
-        poetry run pytest
+      run: poetry run pytest
     - name: Type check
-      run: |
-        poetry run pytype .
+      run: poetry run pytype .
 
     # Build the package
     - name: Build the package
-      run: |
-        poetry build
+      run: poetry build
     - name: Archive build artifacts
       uses: actions/upload-artifact@v4
       if: github.ref == 'refs/heads/release'
       with:
         name: build-artifacts
         path: dist/
-  
+
     # Build the docs
     - name: Build the docs
-      run: |
-        poetry run make html --directory docs
+      run: poetry run make html --directory docs
+      
     - name: Archive documentation
       uses: actions/upload-artifact@v4
       if: github.ref == 'refs/heads/release'

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,10 +4,10 @@
 ```{toctree}
 :maxdepth: 1
 :caption: Tutorials
-tutorials/data_preparation.ipynb
-tutorials/gait_analysis.ipynb
-tutorials/tremor_analysis.ipynb
-tutorials/heart_rate_analysis.ipynb
+tutorials/_static/data_preparation.md
+tutorials/_static/gait_analysis.md
+tutorials/_static/tremor_analysis.md
+tutorials/_static/heart_rate_analysis.md
 ```
 
 ```{toctree}

--- a/docs/tutorials/_static/data_preparation.md
+++ b/docs/tutorials/_static/data_preparation.md
@@ -1,0 +1,765 @@
+# Data preparation
+ParaDigMa requires the sensor data to be of a specific format. This tutorial provides examples of how to prepare your input data for subsequent analysis. In the end, the input for ParaDigMa is a dataframe consisting of:
+* A column `time`, representing the seconds relative to the first row of the dataframe;
+* One or multiple of the following sensor column categories:
+  * Accelerometer: `accelerometer_x`, `accelerometer_y` and `accelerometer_z` in _g_
+  * Gyroscope: `gyroscope_x`, `gyroscope_y` and `gyroscope_z` in _deg/s_
+  * PPG: `green` 
+
+The final dataframe should be resampled to 100 Hz, have the correct units for the sensor columns, and the correct format for the `time` column. Also note that the _gait_ pipeline expects a specific orientation of sensor axes, as explained in [Coordinate system](../guides/coordinate_system.md).
+
+## Load data
+This example uses data of the [Personalized Parkinson Project](https://pubmed.ncbi.nlm.nih.gov/31315608/), which is stored in Time Series Data Format (TSDF). Inertial Measurements Units (IMU) and photoplethysmography (PPG) data are sampled at a different sampling frequency and therefore stored separately. Note that ParaDigMa works independent of data storage format; it only requires a `pandas` dataframe as input.
+
+
+```python
+from pathlib import Path
+from paradigma.util import load_tsdf_dataframe
+
+path_to_raw_data = Path('../../tests/data/data_preparation_tutorial')
+path_to_imu_data = path_to_raw_data / 'imu'
+
+df_imu, imu_time, imu_values = load_tsdf_dataframe(
+    path_to_data=path_to_imu_data, 
+    prefix='IMU'
+)
+
+df_imu.head()
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>acceleration_x</th>
+      <th>acceleration_y</th>
+      <th>acceleration_z</th>
+      <th>rotation_x</th>
+      <th>rotation_y</th>
+      <th>rotation_z</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.000000</td>
+      <td>-5.402541</td>
+      <td>5.632536</td>
+      <td>-2.684842</td>
+      <td>-115.670732</td>
+      <td>-32.012195</td>
+      <td>26.097561</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>10.040039</td>
+      <td>-5.257034</td>
+      <td>6.115995</td>
+      <td>-2.497091</td>
+      <td>-110.609757</td>
+      <td>-34.634146</td>
+      <td>24.695122</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>10.040039</td>
+      <td>-4.947244</td>
+      <td>6.392928</td>
+      <td>-2.468928</td>
+      <td>-103.231708</td>
+      <td>-36.768293</td>
+      <td>22.926829</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>10.040039</td>
+      <td>-4.792349</td>
+      <td>6.735574</td>
+      <td>-2.605048</td>
+      <td>-96.280488</td>
+      <td>-38.719512</td>
+      <td>21.158537</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>10.039795</td>
+      <td>-4.848675</td>
+      <td>7.115770</td>
+      <td>-2.731780</td>
+      <td>-92.560976</td>
+      <td>-41.280488</td>
+      <td>20.304878</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+
+```python
+import os
+from paradigma.util import load_tsdf_dataframe
+
+path_to_ppg_data = os.path.join(path_to_raw_data, 'ppg')
+
+df_ppg, ppg_time, ppg_values = load_tsdf_dataframe(
+    path_to_data=path_to_ppg_data, 
+    prefix='PPG'
+)
+
+df_ppg.head()
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>green</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.000000</td>
+      <td>649511</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>9.959961</td>
+      <td>648214</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>9.959961</td>
+      <td>646786</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>9.959961</td>
+      <td>645334</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>9.960205</td>
+      <td>644317</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+The timestamps in this dataset correspond to delta milliseconds, and the data is not uniformly distributed as can be observed.
+
+## Prepare dataframe
+
+#### Change column names
+To safeguard robustness of the pipeline, ParaDigMa fixes column names to a predefined standard.
+
+
+```python
+from paradigma.constants import DataColumns
+
+accelerometer_columns = [DataColumns.ACCELEROMETER_X, DataColumns.ACCELEROMETER_Y, DataColumns.ACCELEROMETER_Z]
+gyroscope_columns = [DataColumns.GYROSCOPE_X, DataColumns.GYROSCOPE_Y, DataColumns.GYROSCOPE_Z]
+
+# Rename dataframe columns
+df_imu = df_imu.rename(columns={
+    'time': DataColumns.TIME,
+    'acceleration_x': DataColumns.ACCELEROMETER_X,
+    'acceleration_y': DataColumns.ACCELEROMETER_Y,
+    'acceleration_z': DataColumns.ACCELEROMETER_Z,
+    'rotation_x': DataColumns.GYROSCOPE_X,
+    'rotation_y': DataColumns.GYROSCOPE_Y,
+    'rotation_z': DataColumns.GYROSCOPE_Z,
+})
+
+# Set columns to a fixed order
+df_imu = df_imu[[DataColumns.TIME] + accelerometer_columns + gyroscope_columns]
+
+df_imu.head()
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>accelerometer_x</th>
+      <th>accelerometer_y</th>
+      <th>accelerometer_z</th>
+      <th>gyroscope_x</th>
+      <th>gyroscope_y</th>
+      <th>gyroscope_z</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.000000</td>
+      <td>-5.402541</td>
+      <td>5.632536</td>
+      <td>-2.684842</td>
+      <td>-115.670732</td>
+      <td>-32.012195</td>
+      <td>26.097561</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>10.040039</td>
+      <td>-5.257034</td>
+      <td>6.115995</td>
+      <td>-2.497091</td>
+      <td>-110.609757</td>
+      <td>-34.634146</td>
+      <td>24.695122</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>10.040039</td>
+      <td>-4.947244</td>
+      <td>6.392928</td>
+      <td>-2.468928</td>
+      <td>-103.231708</td>
+      <td>-36.768293</td>
+      <td>22.926829</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>10.040039</td>
+      <td>-4.792349</td>
+      <td>6.735574</td>
+      <td>-2.605048</td>
+      <td>-96.280488</td>
+      <td>-38.719512</td>
+      <td>21.158537</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>10.039795</td>
+      <td>-4.848675</td>
+      <td>7.115770</td>
+      <td>-2.731780</td>
+      <td>-92.560976</td>
+      <td>-41.280488</td>
+      <td>20.304878</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+
+```python
+from paradigma.constants import DataColumns
+
+ppg_columns = [DataColumns.PPG]
+
+# Rename dataframe columns
+df_ppg = df_ppg.rename(columns={
+    'time': DataColumns.TIME,
+    'ppg': DataColumns.PPG,
+})
+
+# Set columns to a fixed order
+df_ppg = df_ppg[[DataColumns.TIME] + ppg_columns]
+
+df_ppg.head()
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>green</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.000000</td>
+      <td>649511</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>9.959961</td>
+      <td>648214</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>9.959961</td>
+      <td>646786</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>9.959961</td>
+      <td>645334</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>9.960205</td>
+      <td>644317</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+#### Change units
+ParaDigMa expects acceleration to be measured in g, and rotation in deg/s. Units can be converted conveniently using ParaDigMa functionalities.
+
+
+```python
+from paradigma.util import convert_units_accelerometer, convert_units_gyroscope
+
+accelerometer_units = 'm/s^2'
+gyroscope_units = 'deg/s'
+
+accelerometer_data = df_imu[accelerometer_columns].values
+gyroscope_data = df_imu[gyroscope_columns].values
+
+# Convert units to expected format
+df_imu[accelerometer_columns] = convert_units_accelerometer(accelerometer_data, accelerometer_units)
+df_imu[gyroscope_columns] = convert_units_gyroscope(gyroscope_data, gyroscope_units)
+
+df_imu.head()
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>accelerometer_x</th>
+      <th>accelerometer_y</th>
+      <th>accelerometer_z</th>
+      <th>gyroscope_x</th>
+      <th>gyroscope_y</th>
+      <th>gyroscope_z</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.000000</td>
+      <td>-0.550718</td>
+      <td>0.574163</td>
+      <td>-0.273684</td>
+      <td>-115.670732</td>
+      <td>-32.012195</td>
+      <td>26.097561</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>10.040039</td>
+      <td>-0.535885</td>
+      <td>0.623445</td>
+      <td>-0.254545</td>
+      <td>-110.609757</td>
+      <td>-34.634146</td>
+      <td>24.695122</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>10.040039</td>
+      <td>-0.504306</td>
+      <td>0.651675</td>
+      <td>-0.251675</td>
+      <td>-103.231708</td>
+      <td>-36.768293</td>
+      <td>22.926829</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>10.040039</td>
+      <td>-0.488517</td>
+      <td>0.686603</td>
+      <td>-0.265550</td>
+      <td>-96.280488</td>
+      <td>-38.719512</td>
+      <td>21.158537</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>10.039795</td>
+      <td>-0.494258</td>
+      <td>0.725359</td>
+      <td>-0.278469</td>
+      <td>-92.560976</td>
+      <td>-41.280488</td>
+      <td>20.304878</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+#### Account for watch side
+For the Gait & Arm Swing pipeline, it is essential to ensure correct sensor axes orientation. For more information please read [Coordinate System](../guides/coordinate_system.md) and set the axes of the data accordingly.
+
+
+```python
+# Change the orientation of the sensor according to the documented coordinate system
+df_imu[DataColumns.ACCELEROMETER_Y] *= -1
+df_imu[DataColumns.ACCELEROMETER_Z] *= -1
+df_imu[DataColumns.GYROSCOPE_Y] *= -1
+df_imu[DataColumns.GYROSCOPE_Z] *= -1
+
+df_imu.head()
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>accelerometer_x</th>
+      <th>accelerometer_y</th>
+      <th>accelerometer_z</th>
+      <th>gyroscope_x</th>
+      <th>gyroscope_y</th>
+      <th>gyroscope_z</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.000000</td>
+      <td>-0.550718</td>
+      <td>-0.574163</td>
+      <td>0.273684</td>
+      <td>-115.670732</td>
+      <td>32.012195</td>
+      <td>-26.097561</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>10.040039</td>
+      <td>-0.535885</td>
+      <td>-0.623445</td>
+      <td>0.254545</td>
+      <td>-110.609757</td>
+      <td>34.634146</td>
+      <td>-24.695122</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>10.040039</td>
+      <td>-0.504306</td>
+      <td>-0.651675</td>
+      <td>0.251675</td>
+      <td>-103.231708</td>
+      <td>36.768293</td>
+      <td>-22.926829</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>10.040039</td>
+      <td>-0.488517</td>
+      <td>-0.686603</td>
+      <td>0.265550</td>
+      <td>-96.280488</td>
+      <td>38.719512</td>
+      <td>-21.158537</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>10.039795</td>
+      <td>-0.494258</td>
+      <td>-0.725359</td>
+      <td>0.278469</td>
+      <td>-92.560976</td>
+      <td>41.280488</td>
+      <td>-20.304878</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+#### Change time column
+ParaDigMa expects the data to be in seconds relative to the first row, which should be equal to 0. The toolbox has the built-in function `transform_time_array` to help users transform their time column to the correct format if the timestamps have been sampled in delta time between timestamps. In the near future, the functionalities for transforming other types (e.g., datetime format) shall be provided.
+
+
+```python
+from paradigma.constants import TimeUnit
+from paradigma.util import transform_time_array
+
+df_imu[DataColumns.TIME] = transform_time_array(
+    time_array=df_imu[DataColumns.TIME], 
+    input_unit_type=TimeUnit.DIFFERENCE_MS, 
+    output_unit_type=TimeUnit.RELATIVE_S,
+)
+
+df_imu.head()
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>accelerometer_x</th>
+      <th>accelerometer_y</th>
+      <th>accelerometer_z</th>
+      <th>gyroscope_x</th>
+      <th>gyroscope_y</th>
+      <th>gyroscope_z</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.00000</td>
+      <td>-0.550718</td>
+      <td>-0.574163</td>
+      <td>0.273684</td>
+      <td>-115.670732</td>
+      <td>32.012195</td>
+      <td>-26.097561</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>0.01004</td>
+      <td>-0.535885</td>
+      <td>-0.623445</td>
+      <td>0.254545</td>
+      <td>-110.609757</td>
+      <td>34.634146</td>
+      <td>-24.695122</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>0.02008</td>
+      <td>-0.504306</td>
+      <td>-0.651675</td>
+      <td>0.251675</td>
+      <td>-103.231708</td>
+      <td>36.768293</td>
+      <td>-22.926829</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>0.03012</td>
+      <td>-0.488517</td>
+      <td>-0.686603</td>
+      <td>0.265550</td>
+      <td>-96.280488</td>
+      <td>38.719512</td>
+      <td>-21.158537</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>0.04016</td>
+      <td>-0.494258</td>
+      <td>-0.725359</td>
+      <td>0.278469</td>
+      <td>-92.560976</td>
+      <td>41.280488</td>
+      <td>-20.304878</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+
+```python
+from paradigma.constants import TimeUnit
+from paradigma.util import transform_time_array
+
+df_ppg[DataColumns.TIME] = transform_time_array(
+    time_array=df_ppg[DataColumns.TIME], 
+    input_unit_type=TimeUnit.DIFFERENCE_MS, 
+    output_unit_type=TimeUnit.RELATIVE_S,
+)
+
+df_ppg.head()
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>green</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.00000</td>
+      <td>649511</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>0.00996</td>
+      <td>648214</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>0.01992</td>
+      <td>646786</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>0.02988</td>
+      <td>645334</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>0.03984</td>
+      <td>644317</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+These dataframes are ready to be processed by ParaDigMa.

--- a/docs/tutorials/_static/gait_analysis.md
+++ b/docs/tutorials/_static/gait_analysis.md
@@ -1,0 +1,1437 @@
+# Gait analysis
+This tutorial showcases the high-level functions composing the gait pipeline. Before following along, make sure all data preparation steps have been followed in the data preparation tutorial. 
+
+In this tutorial, we use two days of data from a participant of the Personalized Parkinson Project to demonstrate the functionalities. Since `ParaDigMa` expects contiguous time series, the collected data was stored in two segments each with contiguous timestamps. Per segment, we load the data and perform the following steps:
+1. Data preprocessing
+2. Gait feature extraction
+3. Gait detection
+4. Arm activity feature extraction
+5. Filtering gait
+6. Arm swing quantification
+
+We then combine the output of the different raw data segments for the final step:
+
+7. Aggregation
+
+To run the complete gait pipeline, a prerequisite is to have both accelerometer and gyroscope data, although the first three steps can be completed using only accelerometer data.
+
+[!WARNING] The gait pipeline has been developed on data of the Gait Up Physilog 4, and is currently being validated on the Verily Study Watch. Different sensors and positions on the wrist may affect outcomes.
+
+## Load data
+Here, we start by loading a single contiguous time series (segment), for which we continue running steps 1-6. [Below](#multiple_segments_cell) we show how to run these steps for multiple raw data segments.
+
+We use the interally developed `TSDF` ([documentation](https://biomarkersparkinson.github.io/tsdf/)) to load and store data [[1](https://arxiv.org/abs/2211.11294)]. Depending on the file extension of your time series data, examples of other Python functions for loading the data into memory include:
+- _.csv_: `pandas.read_csv()` ([documentation](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html))
+- _.json_: `json.load()` ([documentation](https://docs.python.org/3/library/json.html#json.load))
+
+
+```python
+from pathlib import Path
+from paradigma.util import load_tsdf_dataframe
+
+# Set the path to where the prepared data is saved and load the data.
+# Note: the test data is stored in TSDF, but you can load your data in your own way
+path_to_data =  Path('../../example_data')
+path_to_prepared_data = path_to_data / 'imu'
+
+raw_data_segment_nr  = '0001' 
+
+# Load the data from the file
+df_imu, metadata_time, metadata_values = load_tsdf_dataframe(path_to_prepared_data, prefix=f'IMU_segment{raw_data_segment_nr}')
+
+df_imu
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>accelerometer_x</th>
+      <th>accelerometer_y</th>
+      <th>accelerometer_z</th>
+      <th>gyroscope_x</th>
+      <th>gyroscope_y</th>
+      <th>gyroscope_z</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.000000</td>
+      <td>-0.474641</td>
+      <td>-0.379426</td>
+      <td>0.770335</td>
+      <td>0.000000</td>
+      <td>1.402439</td>
+      <td>0.243902</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>0.009933</td>
+      <td>-0.472727</td>
+      <td>-0.378947</td>
+      <td>0.765072</td>
+      <td>0.426829</td>
+      <td>0.670732</td>
+      <td>-0.121951</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>0.019867</td>
+      <td>-0.471770</td>
+      <td>-0.375598</td>
+      <td>0.766986</td>
+      <td>1.158537</td>
+      <td>-0.060976</td>
+      <td>-0.304878</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>0.029800</td>
+      <td>-0.472727</td>
+      <td>-0.375598</td>
+      <td>0.770335</td>
+      <td>1.158537</td>
+      <td>-0.548780</td>
+      <td>-0.548780</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>0.039733</td>
+      <td>-0.475120</td>
+      <td>-0.379426</td>
+      <td>0.772249</td>
+      <td>0.670732</td>
+      <td>-0.609756</td>
+      <td>-0.731707</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>3455326</th>
+      <td>34339.561333</td>
+      <td>-0.257895</td>
+      <td>-0.319139</td>
+      <td>-0.761244</td>
+      <td>159.329269</td>
+      <td>14.634146</td>
+      <td>-28.658537</td>
+    </tr>
+    <tr>
+      <th>3455327</th>
+      <td>34339.571267</td>
+      <td>-0.555502</td>
+      <td>-0.153110</td>
+      <td>-0.671292</td>
+      <td>125.060976</td>
+      <td>-213.902440</td>
+      <td>-19.329268</td>
+    </tr>
+    <tr>
+      <th>3455328</th>
+      <td>34339.581200</td>
+      <td>-0.286124</td>
+      <td>-0.263636</td>
+      <td>-0.981340</td>
+      <td>158.658537</td>
+      <td>-328.170733</td>
+      <td>-3.170732</td>
+    </tr>
+    <tr>
+      <th>3455329</th>
+      <td>34339.591133</td>
+      <td>-0.232536</td>
+      <td>-0.161722</td>
+      <td>-0.832536</td>
+      <td>288.841465</td>
+      <td>-281.707318</td>
+      <td>17.073171</td>
+    </tr>
+    <tr>
+      <th>3455330</th>
+      <td>34339.601067</td>
+      <td>0.180383</td>
+      <td>-0.368421</td>
+      <td>-1.525837</td>
+      <td>376.219514</td>
+      <td>-140.853659</td>
+      <td>37.256098</td>
+    </tr>
+  </tbody>
+</table>
+<p>3455331 rows × 7 columns</p>
+</div>
+
+
+
+## Step 1: Preprocess data
+The single function `preprocess_imu_data` in the cell below runs all necessary preprocessing steps. It requires the loaded dataframe, a configuration object `config` specifying parameters used for preprocessing, and a selection of sensors. For the sensors, options include `'accelerometer'`, `'gyroscope'`, or `'both'`.
+
+The function `preprocess_imu_data` processes the data as follows:
+1. Resample the data to ensure uniformly distributed sampling rate
+2. Apply filtering to separate the gravity component from the accelerometer
+
+
+```python
+from paradigma.config import IMUConfig
+from paradigma.preprocessing import preprocess_imu_data
+
+config = IMUConfig()
+
+df_preprocessed = preprocess_imu_data(
+    df=df_imu, 
+    config=config,
+    sensor='both',
+    watch_side='left',
+)
+
+print(f"The dataset of {df_preprocessed.shape[0] / config.sampling_frequency} seconds is automatically resampled to {config.sampling_frequency} Hz.")
+df_preprocessed.head()
+```
+
+    The dataset of 34339.61 seconds is automatically resampled to 100 Hz.
+    
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>accelerometer_x</th>
+      <th>accelerometer_y</th>
+      <th>accelerometer_z</th>
+      <th>gyroscope_x</th>
+      <th>gyroscope_y</th>
+      <th>gyroscope_z</th>
+      <th>accelerometer_x_grav</th>
+      <th>accelerometer_y_grav</th>
+      <th>accelerometer_z_grav</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.00</td>
+      <td>-0.002324</td>
+      <td>-0.001442</td>
+      <td>-0.002116</td>
+      <td>0.000000</td>
+      <td>1.402439</td>
+      <td>0.243902</td>
+      <td>-0.472317</td>
+      <td>-0.377984</td>
+      <td>0.772451</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>0.01</td>
+      <td>-0.000390</td>
+      <td>-0.000914</td>
+      <td>-0.007396</td>
+      <td>0.432231</td>
+      <td>0.665526</td>
+      <td>-0.123434</td>
+      <td>-0.472326</td>
+      <td>-0.378012</td>
+      <td>0.772464</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>0.02</td>
+      <td>0.000567</td>
+      <td>0.002474</td>
+      <td>-0.005445</td>
+      <td>1.164277</td>
+      <td>-0.069584</td>
+      <td>-0.307536</td>
+      <td>-0.472336</td>
+      <td>-0.378040</td>
+      <td>0.772476</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>0.03</td>
+      <td>-0.000425</td>
+      <td>0.002414</td>
+      <td>-0.002099</td>
+      <td>1.151432</td>
+      <td>-0.554928</td>
+      <td>-0.554223</td>
+      <td>-0.472346</td>
+      <td>-0.378068</td>
+      <td>0.772489</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>0.04</td>
+      <td>-0.002807</td>
+      <td>-0.001408</td>
+      <td>-0.000218</td>
+      <td>0.657189</td>
+      <td>-0.603207</td>
+      <td>-0.731570</td>
+      <td>-0.472355</td>
+      <td>-0.378096</td>
+      <td>0.772502</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+The resulting dataframe shown above contains uniformly distributed timestamps with corresponding accelerometer and gyroscope values. Note the for accelerometer values, the following notation is used: 
+- `accelerometer_x`: the accelerometer signal after filtering out the gravitational component
+- `accelerometer_x_grav`: the gravitational component of the accelerometer signal
+
+The accelerometer data is retained and used to compute gravity-related features for the classification tasks, because the gravity is informative of the position of the arm.
+
+## Step 2: Extract gait features
+With the data uniformly resampled and the gravitional component separated from the accelerometer signal, features can be extracted from the time series data. This step does not require gyroscope data. To extract the features, the pipeline executes the following steps:
+- Use overlapping windows to group timestamps
+- Extract temporal features
+- Use Fast Fourier Transform the transform the windowed data into the spectral domain
+- Extract spectral features
+- Combine both temporal and spectral features into a final dataframe
+
+These steps are encapsulated in `extract_gait_features` (documentation can be found [here](https://github.com/biomarkersParkinson/paradigma/blob/main/src/paradigma/pipelines/gait_pipeline.py)).
+
+
+```python
+from paradigma.config import GaitConfig
+from paradigma.pipelines.gait_pipeline import extract_gait_features
+
+config = GaitConfig(step='gait')
+
+df_gait = extract_gait_features(
+    df=df_preprocessed, 
+    config=config
+)
+
+print(f"A total of {df_gait.shape[1]-1} features have been extracted from {df_gait.shape[0]} {config.window_length_s}-second windows with {config.window_length_s-config.window_step_length_s} seconds overlap.")
+df_gait.head()
+```
+
+    A total of 34 features have been extracted from 34334 6-second windows with 5 seconds overlap.
+    
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>accelerometer_x_grav_mean</th>
+      <th>accelerometer_y_grav_mean</th>
+      <th>accelerometer_z_grav_mean</th>
+      <th>accelerometer_x_grav_std</th>
+      <th>accelerometer_y_grav_std</th>
+      <th>accelerometer_z_grav_std</th>
+      <th>accelerometer_std_norm</th>
+      <th>accelerometer_x_power_below_gait</th>
+      <th>accelerometer_y_power_below_gait</th>
+      <th>...</th>
+      <th>accelerometer_mfcc_3</th>
+      <th>accelerometer_mfcc_4</th>
+      <th>accelerometer_mfcc_5</th>
+      <th>accelerometer_mfcc_6</th>
+      <th>accelerometer_mfcc_7</th>
+      <th>accelerometer_mfcc_8</th>
+      <th>accelerometer_mfcc_9</th>
+      <th>accelerometer_mfcc_10</th>
+      <th>accelerometer_mfcc_11</th>
+      <th>accelerometer_mfcc_12</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.0</td>
+      <td>-0.472967</td>
+      <td>-0.380588</td>
+      <td>0.774287</td>
+      <td>0.000270</td>
+      <td>0.000818</td>
+      <td>0.000574</td>
+      <td>0.003377</td>
+      <td>0.000003</td>
+      <td>1.188086e-06</td>
+      <td>...</td>
+      <td>-1.101486</td>
+      <td>0.524288</td>
+      <td>0.215990</td>
+      <td>0.429154</td>
+      <td>0.900923</td>
+      <td>1.135918</td>
+      <td>0.673404</td>
+      <td>-0.128276</td>
+      <td>-0.335655</td>
+      <td>-0.060155</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>1.0</td>
+      <td>-0.473001</td>
+      <td>-0.380704</td>
+      <td>0.774541</td>
+      <td>0.000235</td>
+      <td>0.000588</td>
+      <td>0.000220</td>
+      <td>0.003194</td>
+      <td>0.000003</td>
+      <td>1.210176e-06</td>
+      <td>...</td>
+      <td>-0.997314</td>
+      <td>0.633275</td>
+      <td>0.327645</td>
+      <td>0.451613</td>
+      <td>0.972729</td>
+      <td>1.120786</td>
+      <td>0.770134</td>
+      <td>-0.115916</td>
+      <td>-0.395856</td>
+      <td>-0.011206</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>2.0</td>
+      <td>-0.473036</td>
+      <td>-0.380563</td>
+      <td>0.774578</td>
+      <td>0.000233</td>
+      <td>0.000619</td>
+      <td>0.000195</td>
+      <td>0.003188</td>
+      <td>0.000002</td>
+      <td>6.693551e-07</td>
+      <td>...</td>
+      <td>-1.040592</td>
+      <td>0.404720</td>
+      <td>0.268514</td>
+      <td>0.507473</td>
+      <td>0.944706</td>
+      <td>1.016282</td>
+      <td>0.785686</td>
+      <td>-0.071433</td>
+      <td>-0.414269</td>
+      <td>0.020690</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>3.0</td>
+      <td>-0.472952</td>
+      <td>-0.380310</td>
+      <td>0.774660</td>
+      <td>0.000301</td>
+      <td>0.000526</td>
+      <td>0.000326</td>
+      <td>0.003020</td>
+      <td>0.000002</td>
+      <td>6.835856e-07</td>
+      <td>...</td>
+      <td>-1.075637</td>
+      <td>0.258352</td>
+      <td>0.257234</td>
+      <td>0.506739</td>
+      <td>0.892823</td>
+      <td>0.900388</td>
+      <td>0.706368</td>
+      <td>-0.080562</td>
+      <td>-0.302595</td>
+      <td>0.054805</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>4.0</td>
+      <td>-0.472692</td>
+      <td>-0.380024</td>
+      <td>0.774889</td>
+      <td>0.000468</td>
+      <td>0.000355</td>
+      <td>0.000470</td>
+      <td>0.002869</td>
+      <td>0.000002</td>
+      <td>1.097557e-06</td>
+      <td>...</td>
+      <td>-1.079496</td>
+      <td>0.264418</td>
+      <td>0.237172</td>
+      <td>0.587941</td>
+      <td>0.936835</td>
+      <td>0.763372</td>
+      <td>0.607845</td>
+      <td>-0.159721</td>
+      <td>-0.184856</td>
+      <td>0.128150</td>
+    </tr>
+  </tbody>
+</table>
+<p>5 rows × 35 columns</p>
+</div>
+
+
+
+Each row in this dataframe corresponds to a single window, with the window length and overlap set in the `config` object. Note that the `time` column has a 1-second interval instead of the 10-millisecond interval before, as it now represents the starting time of the window.
+
+## Step 3: Gait detection
+For classification, ParaDigMa uses so-called Classifier Packages which contain a classifier, classification threshold, and a feature scaler as attributes. The classifier is a [random forest](https://scikit-learn.org/1.5/modules/generated/sklearn.ensemble.RandomForestClassifier.html) trained on a dataset of people with PD performing a wide range of activities in free-living conditions: [The Parkinson@Home Validation Study](https://pmc.ncbi.nlm.nih.gov/articles/PMC7584982/). The classification threshold was set to limit the amount of false-positive predictions in the original study, i.e., to limit non-gait to be predicted as gait. The classification threshold can be changed by setting `clf_package.threshold` to a different float value. The feature scaler was similarly fitted on the original dataset, ensuring the features are within expected confined spaces to make reliable predictions.
+
+
+```python
+from importlib.resources import files
+from paradigma.classification import ClassifierPackage
+from paradigma.pipelines.gait_pipeline import detect_gait
+
+# Set the path to the classifier package
+classifier_package_filename = 'gait_detection_clf_package.pkl'
+full_path_to_classifier_package = files('paradigma') / 'assets' / classifier_package_filename
+
+# Load the classifier package
+clf_package_detection = ClassifierPackage.load(full_path_to_classifier_package)
+
+# Detecting gait returns the probability of gait for each window, which is concatenated to
+# the original dataframe
+df_gait['pred_gait_proba'] = detect_gait(
+    df=df_gait,
+    clf_package=clf_package_detection
+)
+
+n_windows = df_gait.shape[0]
+n_predictions_gait = df_gait.loc[df_gait['pred_gait_proba'] >= clf_package_detection.threshold].shape[0]
+perc_predictions_gait = round(100 * n_predictions_gait / n_windows, 1)
+n_predictions_non_gait = df_gait.loc[df_gait['pred_gait_proba'] < clf_package_detection.threshold].shape[0]
+perc_predictions_non_gait = round(100 * n_predictions_non_gait / n_windows, 1)
+
+print(f"Out of {n_windows} windows, {n_predictions_gait} ({perc_predictions_gait}%) were predicted as gait, and {n_predictions_non_gait} ({perc_predictions_non_gait}%) as non-gait.")
+
+# Only the time and the predicted gait probability are shown, but the dataframe also contains
+# the extracted features
+df_gait[['time', 'pred_gait_proba']].head()
+```
+
+    Out of 34334 windows, 2753 (8.0%) were predicted as gait, and 31581 (92.0%) as non-gait.
+    
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>pred_gait_proba</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.0</td>
+      <td>0.000023</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>1.0</td>
+      <td>0.000024</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>2.0</td>
+      <td>0.000023</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>3.0</td>
+      <td>0.000023</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>4.0</td>
+      <td>0.000023</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+#### Store as TSDF
+The predicted probabilities (and optionally other features) can be stored and loaded in TSDF as demonstrated below. 
+
+
+```python
+import tsdf
+from paradigma.util import write_df_data
+
+# Set 'path_to_data' to the directory where you want to save the data
+metadata_time_store = tsdf.TSDFMetadata(metadata_time.get_plain_tsdf_dict_copy(), path_to_data)
+metadata_values_store = tsdf.TSDFMetadata(metadata_values.get_plain_tsdf_dict_copy(), path_to_data)
+
+# Select the columns to be saved 
+metadata_time_store.channels = ['time']
+metadata_values_store.channels = ['pred_gait_proba']
+
+# Set the units
+metadata_time_store.units = ['Relative seconds']
+metadata_values_store.units = ['Unitless']
+metadata_time_store.data_type = float
+metadata_values_store.data_type = float
+
+# Set the filenames
+meta_store_filename = f'segment{raw_data_segment_nr}_meta.json'
+values_store_filename = meta_store_filename.replace('_meta.json', '_values.bin')
+time_store_filename = meta_store_filename.replace('_meta.json', '_time.bin')
+
+metadata_values_store.file_name = values_store_filename
+metadata_time_store.file_name = time_store_filename
+
+write_df_data(metadata_time_store, metadata_values_store, path_to_data, meta_store_filename, df_gait)
+```
+
+
+```python
+df_gait, _, _ = load_tsdf_dataframe(path_to_data, prefix=f'segment{raw_data_segment_nr}')
+df_gait.head()
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>pred_gait_proba</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.0</td>
+      <td>0.000023</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>1.0</td>
+      <td>0.000024</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>2.0</td>
+      <td>0.000023</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>3.0</td>
+      <td>0.000023</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>4.0</td>
+      <td>0.000023</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+Once again, the `time` column indicates the start time of the window. Therefore, it can be observed that probabilities are predicted of overlapping windows, and not of individual timestamps. The function [`merge_timestamps_with_predictions`](https://github.com/biomarkersParkinson/paradigma/blob/main/src/paradigma/util.py) can be used to retrieve predicted probabilities per timestamp by aggregating the predicted probabilities of overlapping windows. This function is included in the next step.
+
+## Step 4: Arm activity feature extraction
+The extraction of arm swing features is similar to the extraction of gait features, but we use a different window length and step length (`config.window_length_s`, `config.window_step_length_s`) to distinguish between gait segments with and without other arm activities. Therefore, the following steps are conducted sequentially by `extract_arm_activity_features`:
+- Start with the preprocessed data of step 1
+- Merge the gait predictions into the preprocessed data
+- Discard predicted non-gait activities
+- Create windows of the time series data and extract features
+
+But, first, the gait predictions should be merged with the preprocessed time series data, such that individual timestamps have a corresponding probability of gait. The function `extract_arm_activity_features` expects a time series dataframe of predicted gait.
+
+
+```python
+from paradigma.constants import DataColumns
+from paradigma.util import merge_predictions_with_timestamps
+
+# Merge gait predictions into timeseries data
+if not any(df_gait[DataColumns.PRED_GAIT_PROBA] >= clf_package_detection.threshold):
+    raise ValueError("No gait detected in the input data.")
+
+gait_preprocessing_config = GaitConfig(step='gait')
+
+df = merge_predictions_with_timestamps(
+    df_ts=df_preprocessed, 
+    df_predictions=df_gait, 
+    pred_proba_colname=DataColumns.PRED_GAIT_PROBA,
+    window_length_s=gait_preprocessing_config.window_length_s,
+    fs=gait_preprocessing_config.sampling_frequency
+)
+
+# Add a column for predicted gait based on a fitted threshold
+df[DataColumns.PRED_GAIT] = (df[DataColumns.PRED_GAIT_PROBA] >= clf_package_detection.threshold).astype(int)
+
+# Filter the DataFrame to only include predicted gait (1)
+df = df.loc[df[DataColumns.PRED_GAIT]==1].reset_index(drop=True)
+```
+
+
+```python
+from paradigma.pipelines.gait_pipeline import extract_arm_activity_features
+
+config = GaitConfig(step='arm_activity')
+
+df_arm_activity = extract_arm_activity_features(
+    df=df, 
+    config=config,
+)
+
+print(f"A total of {df_arm_activity.shape[1] - 1} features have been extracted from {df_arm_activity.shape[0]} {config.window_length_s} - second windows with {config.window_length_s - config.window_step_length_s} seconds overlap.")
+df_arm_activity.head()
+```
+
+    A total of 61 features have been extracted from 2749 3 - second windows with 2.25 seconds overlap.
+    
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>accelerometer_x_grav_mean</th>
+      <th>accelerometer_y_grav_mean</th>
+      <th>accelerometer_z_grav_mean</th>
+      <th>accelerometer_x_grav_std</th>
+      <th>accelerometer_y_grav_std</th>
+      <th>accelerometer_z_grav_std</th>
+      <th>accelerometer_std_norm</th>
+      <th>accelerometer_x_power_below_gait</th>
+      <th>accelerometer_y_power_below_gait</th>
+      <th>...</th>
+      <th>gyroscope_mfcc_3</th>
+      <th>gyroscope_mfcc_4</th>
+      <th>gyroscope_mfcc_5</th>
+      <th>gyroscope_mfcc_6</th>
+      <th>gyroscope_mfcc_7</th>
+      <th>gyroscope_mfcc_8</th>
+      <th>gyroscope_mfcc_9</th>
+      <th>gyroscope_mfcc_10</th>
+      <th>gyroscope_mfcc_11</th>
+      <th>gyroscope_mfcc_12</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>1463.00</td>
+      <td>-0.941812</td>
+      <td>-0.216149</td>
+      <td>-0.129170</td>
+      <td>0.031409</td>
+      <td>0.089397</td>
+      <td>0.060771</td>
+      <td>0.166084</td>
+      <td>0.000596</td>
+      <td>0.007746</td>
+      <td>...</td>
+      <td>-0.555190</td>
+      <td>0.735644</td>
+      <td>0.180382</td>
+      <td>0.044897</td>
+      <td>-0.645257</td>
+      <td>-0.255383</td>
+      <td>0.121998</td>
+      <td>0.297776</td>
+      <td>0.326170</td>
+      <td>0.348648</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>1463.75</td>
+      <td>-0.933787</td>
+      <td>-0.198807</td>
+      <td>-0.092710</td>
+      <td>0.045961</td>
+      <td>0.066987</td>
+      <td>0.038606</td>
+      <td>0.363777</td>
+      <td>0.001216</td>
+      <td>0.002593</td>
+      <td>...</td>
+      <td>-0.722972</td>
+      <td>0.686450</td>
+      <td>-0.254451</td>
+      <td>-0.282469</td>
+      <td>-0.798232</td>
+      <td>-0.100043</td>
+      <td>0.028278</td>
+      <td>0.114591</td>
+      <td>0.160311</td>
+      <td>0.372009</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>1464.50</td>
+      <td>-0.882285</td>
+      <td>-0.265160</td>
+      <td>-0.080937</td>
+      <td>0.094924</td>
+      <td>0.146720</td>
+      <td>0.021218</td>
+      <td>0.362434</td>
+      <td>0.002429</td>
+      <td>0.001315</td>
+      <td>...</td>
+      <td>-1.134321</td>
+      <td>0.773245</td>
+      <td>-0.218279</td>
+      <td>-0.430585</td>
+      <td>-0.437373</td>
+      <td>-0.065236</td>
+      <td>0.014411</td>
+      <td>0.083823</td>
+      <td>0.181666</td>
+      <td>0.079949</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>1465.25</td>
+      <td>-0.794800</td>
+      <td>-0.405043</td>
+      <td>-0.094178</td>
+      <td>0.126863</td>
+      <td>0.212621</td>
+      <td>0.034948</td>
+      <td>0.363425</td>
+      <td>0.004974</td>
+      <td>0.008407</td>
+      <td>...</td>
+      <td>-1.154252</td>
+      <td>1.024267</td>
+      <td>-0.161531</td>
+      <td>-0.217479</td>
+      <td>-0.153630</td>
+      <td>-0.016550</td>
+      <td>0.119570</td>
+      <td>0.095287</td>
+      <td>0.231406</td>
+      <td>0.015294</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>1466.00</td>
+      <td>-0.691081</td>
+      <td>-0.578715</td>
+      <td>-0.118220</td>
+      <td>0.127414</td>
+      <td>0.219660</td>
+      <td>0.035758</td>
+      <td>0.360352</td>
+      <td>0.003998</td>
+      <td>0.004305</td>
+      <td>...</td>
+      <td>-0.763188</td>
+      <td>0.763812</td>
+      <td>-0.158849</td>
+      <td>-0.023935</td>
+      <td>-0.006564</td>
+      <td>-0.185257</td>
+      <td>-0.120585</td>
+      <td>0.090823</td>
+      <td>0.171506</td>
+      <td>-0.038381</td>
+    </tr>
+  </tbody>
+</table>
+<p>5 rows × 62 columns</p>
+</div>
+
+
+
+The features extracted are similar to the features extracted for gait detection, but the gyroscope has been added to extract additional MFCCs of this sensor. The gyroscope (measuring angular velocity) is relevant to distinguish between arm activities. Also note that the `time` column no longer starts at 0, since the first timestamps were predicted as non-gait and therefore discarded.
+
+## Step 5: Filtering gait
+This classification task is similar to gait detection, although it uses a different classification object. The trained classifier is a logistic regression, similarly trained on the dataset of the [Parkinson@Home Validation Study](https://pmc.ncbi.nlm.nih.gov/articles/PMC7584982/). Filtering gait is the process of detecting and removing gait segments containing other arm activities. This is an important process since individuals entertain a wide array of arm activities during gait: having hands in pockets, holding a dog leash, or carrying a plate to the kitchen. We trained a classifier to detect these other arm activities during gait, enabling accurate estimations of the arm swing.
+
+
+```python
+from paradigma.classification import ClassifierPackage
+from paradigma.pipelines.gait_pipeline import filter_gait
+
+# Set the path to the classifier package
+classifier_package_filename = 'gait_filtering_clf_package.pkl'
+full_path_to_classifier_package = files('paradigma') / 'assets' / classifier_package_filename
+
+# Load the classifier package
+clf_package_filtering = ClassifierPackage.load(full_path_to_classifier_package)
+
+# Detecting no_other_arm_activity returns the probability of no_other_arm_activity for each window, which is concatenated to
+# the original dataframe
+df_arm_activity['pred_no_other_arm_activity_proba'] = filter_gait(
+    df=df_arm_activity,
+    clf_package=clf_package_filtering
+)
+
+n_windows = df_arm_activity.shape[0]
+n_predictions_no_other_arm_activity = df_arm_activity.loc[df_arm_activity['pred_no_other_arm_activity_proba']>=clf_package_filtering.threshold].shape[0]
+perc_predictions_no_other_arm_activity = round(100 * n_predictions_no_other_arm_activity / n_windows, 1)
+n_predictions_other_arm_activity = df_arm_activity.loc[df_arm_activity['pred_no_other_arm_activity_proba']<clf_package_filtering.threshold].shape[0]
+perc_predictions_other_arm_activity = round(100 * n_predictions_other_arm_activity / n_windows, 1)
+
+print(f"Out of {n_windows} windows, {n_predictions_no_other_arm_activity} ({perc_predictions_no_other_arm_activity}%) were predicted as no_other_arm_activity, and {n_predictions_other_arm_activity} ({perc_predictions_other_arm_activity}%) as other_arm_activity.")
+
+# Only the time and predicted probabilities are shown, but the dataframe also contains
+# the extracted features
+df_arm_activity[['time', 'pred_no_other_arm_activity_proba']].head()
+```
+
+    Out of 2749 windows, 916 (33.3%) were predicted as no_other_arm_activity, and 1833 (66.7%) as other_arm_activity.
+    
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>pred_no_other_arm_activity_proba</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>1463.00</td>
+      <td>0.199764</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>1463.75</td>
+      <td>0.107982</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>1464.50</td>
+      <td>0.138796</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>1465.25</td>
+      <td>0.168050</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>1466.00</td>
+      <td>0.033986</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+## Step 6: Arm swing quantification
+The next step is to extract arm swing estimates from the predicted gait segments without other arm activities. Arm swing estimates can be calculated for both filtered and unfiltered gait, with the latter being predicted gait including all arm activities. Specifically, the range of motion (`'range_of_motion'`) and peak angular velocity (`'peak_velocity'`) are extracted.  
+
+This step creates gait segments based on consecutively predicted gait windows. A new gait segment is created if the gap between consecutive gait predictions exceeds `config.max_segment_gap_s`. Furthermore, a gait segment is considered valid if it is of at minimum length `config.min_segment_length_s`. 
+
+But, first, similar to the step of extracting arm activity features, the predictions of the previous step should be merged with the preprocessed time series data.
+
+
+```python
+# Merge arm activity predictions into timeseries data
+
+if not any(df_arm_activity[DataColumns.PRED_NO_OTHER_ARM_ACTIVITY_PROBA] >= clf_package_filtering.threshold):
+    raise ValueError("No gait without other arm activities detected in the input data.")
+
+config = GaitConfig(step='arm_activity')
+
+df = merge_predictions_with_timestamps(
+    df_ts=df_preprocessed, 
+    df_predictions=df_arm_activity, 
+    pred_proba_colname=DataColumns.PRED_NO_OTHER_ARM_ACTIVITY_PROBA,
+    window_length_s=config.window_length_s,
+    fs=config.sampling_frequency
+)
+
+# Add a column for predicted gait based on a fitted threshold
+df[DataColumns.PRED_NO_OTHER_ARM_ACTIVITY] = (df[DataColumns.PRED_NO_OTHER_ARM_ACTIVITY_PROBA] >= clf_package_filtering.threshold).astype(int)
+
+# Filter the DataFrame to only include predicted gait (1)
+df = df.loc[df[DataColumns.PRED_NO_OTHER_ARM_ACTIVITY]==1].reset_index(drop=True)
+```
+
+
+```python
+from paradigma.pipelines.gait_pipeline import quantify_arm_swing
+from pprint import pprint
+
+# Set to True to quantify arm swing based on the filtered gait segments, and False
+# to quantify arm swing based on all gait segments
+filtered = True
+
+if filtered:
+    dataset_used = 'filtered'
+    print(f"The arm swing quantification is based on the filtered gait segments.\n")
+else:
+    dataset_used = 'unfiltered'
+    print(f"The arm swing quantification is based on all gait segments.\n")
+
+quantified_arm_swing, gait_segment_meta = quantify_arm_swing(
+    df=df,
+    fs=config.sampling_frequency,
+    filtered=filtered,
+    max_segment_gap_s=config.max_segment_gap_s,
+    min_segment_length_s=config.min_segment_length_s,
+)
+
+print(f"Gait segments are created of minimum {config.min_segment_length_s} seconds and maximum {config.max_segment_gap_s} seconds gap between segments.\n")
+print(f"A total of {quantified_arm_swing['segment_nr'].nunique()} {dataset_used} gait segments have been quantified.")
+
+print(f"\nMetadata of the first gait segment:")
+pprint(gait_segment_meta['per_segment'][1])
+
+print(f"\nIndividual arm swings of the first gait segment of the {dataset_used} dataset:")
+quantified_arm_swing.loc[quantified_arm_swing['segment_nr']==1]
+```
+
+    The arm swing quantification is based on the filtered gait segments.
+    
+    Gait segments are created of minimum 1.5 seconds and maximum 1.5 seconds gap between segments.
+    
+    A total of 84 filtered gait segments have been quantified.
+    
+    Metadata of the first gait segment:
+    {'duration_s': 9.0,
+     'end_time_s': 2230.74,
+     'segment_category': 'moderately_long',
+     'start_time_s': 2221.75}
+    
+    Individual arm swings of the first gait segment of the filtered dataset:
+    
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>segment_nr</th>
+      <th>segment_category</th>
+      <th>range_of_motion</th>
+      <th>peak_velocity</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>1</td>
+      <td>moderately_long</td>
+      <td>19.218491</td>
+      <td>90.807689</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>1</td>
+      <td>moderately_long</td>
+      <td>21.267287</td>
+      <td>105.781357</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>1</td>
+      <td>moderately_long</td>
+      <td>23.582098</td>
+      <td>103.932332</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>1</td>
+      <td>moderately_long</td>
+      <td>23.757712</td>
+      <td>114.846304</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>1</td>
+      <td>moderately_long</td>
+      <td>17.430734</td>
+      <td>63.297391</td>
+    </tr>
+    <tr>
+      <th>5</th>
+      <td>1</td>
+      <td>moderately_long</td>
+      <td>12.139037</td>
+      <td>59.740258</td>
+    </tr>
+    <tr>
+      <th>6</th>
+      <td>1</td>
+      <td>moderately_long</td>
+      <td>6.681346</td>
+      <td>36.802784</td>
+    </tr>
+    <tr>
+      <th>7</th>
+      <td>1</td>
+      <td>moderately_long</td>
+      <td>6.293493</td>
+      <td>30.793498</td>
+    </tr>
+    <tr>
+      <th>8</th>
+      <td>1</td>
+      <td>moderately_long</td>
+      <td>7.892546</td>
+      <td>42.481470</td>
+    </tr>
+    <tr>
+      <th>9</th>
+      <td>1</td>
+      <td>moderately_long</td>
+      <td>9.633521</td>
+      <td>43.837249</td>
+    </tr>
+    <tr>
+      <th>10</th>
+      <td>1</td>
+      <td>moderately_long</td>
+      <td>9.679263</td>
+      <td>38.867993</td>
+    </tr>
+    <tr>
+      <th>11</th>
+      <td>1</td>
+      <td>moderately_long</td>
+      <td>9.437900</td>
+      <td>34.112233</td>
+    </tr>
+    <tr>
+      <th>12</th>
+      <td>1</td>
+      <td>moderately_long</td>
+      <td>9.272199</td>
+      <td>33.344802</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+The gait segment categories are defined as follows:
+- short: < 5 seconds
+- moderately_long: 5-10 seconds
+- long: 10-20 seconds
+- very_long: > 20 seconds
+
+As noted before, the gait segments (and categories) are determined based on predicted gait (unfiltered gait). Therefore, for the arm swing of filtered gait, a gait segment may be smaller as parts of the gait segment were predicted to have other arm activities, yet the category remained the same.
+
+### Run steps 1-6 for the all raw data segment(s) <a id='multiple_segments_cell'></a>
+
+If your data is also stored in multiple raw data segments, you can modify `raw_data_segments` in the cell below to a list of the filenames of your respective segmented data.
+
+
+```python
+import pandas as pd
+from pathlib import Path
+from importlib.resources import files
+from pprint import pprint
+
+from paradigma.util import load_tsdf_dataframe, merge_predictions_with_timestamps
+from paradigma.config import IMUConfig, GaitConfig
+from paradigma.preprocessing import preprocess_imu_data
+from paradigma.pipelines.gait_pipeline import extract_gait_features, detect_gait,extract_arm_activity_features, filter_gait, quantify_arm_swing
+from paradigma.constants import DataColumns
+from paradigma.classification import ClassifierPackage
+
+# Set the path to where the prepared data is saved
+path_to_data =  Path('../../example_data')
+path_to_prepared_data = path_to_data / 'imu'
+
+# Load the gait detection classifier package
+classifier_package_filename = 'gait_detection_clf_package.pkl'
+full_path_to_classifier_package = files('paradigma') / 'assets' / classifier_package_filename
+clf_package_detection = ClassifierPackage.load(full_path_to_classifier_package)
+
+# Load the gait filtering classifier package
+classifier_package_filename = 'gait_filtering_clf_package.pkl'
+full_path_to_classifier_package = files('paradigma') / 'assets' / classifier_package_filename
+clf_package_filtering = ClassifierPackage.load(full_path_to_classifier_package)
+
+# Set to True to quantify arm swing based on the filtered gait segments, and False
+# to quantify arm swing based on all gait segments
+filtered = True
+
+# Create a list to store all quantified arm swing segments 
+list_quantified_arm_swing = []
+
+raw_data_segments  = ['0001','0002'] # list with all available raw data segments
+
+for raw_data_segment_nr in raw_data_segments:
+    
+    # Load the data
+    df_imu, _, _ = load_tsdf_dataframe(path_to_prepared_data, prefix=f'IMU_segment{raw_data_segment_nr}')
+
+    # 1: Preprocess the data
+    config = IMUConfig()
+
+    df_preprocessed = preprocess_imu_data(
+        df=df_imu, 
+        config=config,
+        sensor='both',
+        watch_side='left',
+    )
+
+    # 2: Extract gait features
+    config = GaitConfig(step='gait')
+
+    df_gait = extract_gait_features(
+        df=df_preprocessed, 
+        config=config
+    )
+
+    # 3: Detect gait
+    df_gait['pred_gait_proba'] = detect_gait(
+        df=df_gait,
+        clf_package=clf_package_detection
+    )
+
+    # Merge gait predictions into timeseries data
+    if not any(df_gait[DataColumns.PRED_GAIT_PROBA] >= clf_package_detection.threshold):
+        raise ValueError("No gait detected in the input data.")
+    
+    df = merge_predictions_with_timestamps(
+        df_ts=df_preprocessed, 
+        df_predictions=df_gait, 
+        pred_proba_colname=DataColumns.PRED_GAIT_PROBA,
+        window_length_s=config.window_length_s,
+        fs=config.sampling_frequency
+    )
+
+    df[DataColumns.PRED_GAIT] = (df[DataColumns.PRED_GAIT_PROBA] >= clf_package_detection.threshold).astype(int)
+    df = df.loc[df[DataColumns.PRED_GAIT]==1].reset_index(drop=True)
+
+    # 4: Extract arm activity features
+    config = GaitConfig(step='arm_activity')
+
+    df_arm_activity = extract_arm_activity_features(
+        df=df, 
+        config=config,
+    )
+
+    # 5: Filter gait
+    df_arm_activity['pred_no_other_arm_activity_proba'] = filter_gait(
+        df=df_arm_activity,
+        clf_package=clf_package_filtering
+    )
+
+    # Merge arm activity predictions into timeseries data
+    if not any(df_arm_activity[DataColumns.PRED_NO_OTHER_ARM_ACTIVITY_PROBA] >= clf_package_filtering.threshold):
+        raise ValueError("No gait without other arm activities detected in the input data.")
+
+    df = merge_predictions_with_timestamps(
+        df_ts=df_preprocessed, 
+        df_predictions=df_arm_activity, 
+        pred_proba_colname=DataColumns.PRED_NO_OTHER_ARM_ACTIVITY_PROBA,
+        window_length_s=config.window_length_s,
+        fs=config.sampling_frequency
+    )
+
+    df[DataColumns.PRED_NO_OTHER_ARM_ACTIVITY] = (df[DataColumns.PRED_NO_OTHER_ARM_ACTIVITY_PROBA] >= clf_package_filtering.threshold).astype(int)
+    df = df.loc[df[DataColumns.PRED_NO_OTHER_ARM_ACTIVITY]==1].reset_index(drop=True)
+
+    # 6: Quantify arm swing
+    quantified_arm_swing, gait_segment_meta = quantify_arm_swing(
+        df=df,
+        fs=config.sampling_frequency,
+        filtered=filtered,
+        max_segment_gap_s=config.max_segment_gap_s,
+        min_segment_length_s=config.min_segment_length_s,
+    )
+
+    # Add the predictions of the current raw data segment to the list
+    quantified_arm_swing['raw_data_segment_nr'] = raw_data_segment_nr
+    list_quantified_arm_swing.append(quantified_arm_swing)
+
+quantified_arm_swing = pd.concat(list_quantified_arm_swing, ignore_index=True)
+```
+
+## Step 7: Aggregation
+Finally, the arm swing estimates can be aggregated across all gait segments.
+
+
+```python
+from paradigma.pipelines.gait_pipeline import aggregate_arm_swing_params
+
+arm_swing_aggregations = aggregate_arm_swing_params(
+    df_arm_swing_params=quantified_arm_swing,
+    segment_meta=gait_segment_meta['per_segment'],
+    aggregates=['median', '95p']
+)
+
+pprint(arm_swing_aggregations, sort_dicts=False)
+```
+
+    {'long': {'duration_s': 60.75,
+              'median_range_of_motion': 15.78108745792784,
+              '95p_range_of_motion': 45.16540046751929,
+              'median_peak_velocity': 86.83257977334745,
+              '95p_peak_velocity': 219.97254034894718},
+     'short': {'duration_s': 153.75,
+               'median_range_of_motion': 14.225382307390944,
+               '95p_range_of_motion': 40.53847370093226,
+               'median_peak_velocity': 71.56035976932178,
+               '95p_peak_velocity': 197.13328716416063},
+     'very_long': {'duration_s': 1905.75,
+                   'median_range_of_motion': 25.2896510096605,
+                   '95p_range_of_motion': 43.74907398039543,
+                   'median_peak_velocity': 125.9443142903539,
+                   '95p_peak_velocity': 217.80854223601992},
+     'moderately_long': {'duration_s': 187.5,
+                         'median_range_of_motion': 15.73004566220565,
+                         '95p_range_of_motion': 54.55881567144294,
+                         'median_peak_velocity': 77.94780939826387,
+                         '95p_peak_velocity': 256.9799773546029},
+     'all_segment_categories': {'duration_s': 2307.75,
+                                'median_range_of_motion': 23.100608971051315,
+                                '95p_range_of_motion': 45.92600123148869,
+                                'median_peak_velocity': 116.50364930684765,
+                                '95p_peak_velocity': 219.2008357820751}}
+    
+
+The output of the aggregation step contains the aggregated arm swing parameters per gait segment category. Additionally, the total time in seconds `time_s` is added to inform based on how much data the aggregations were created.

--- a/docs/tutorials/_static/heart_rate_analysis.md
+++ b/docs/tutorials/_static/heart_rate_analysis.md
@@ -1,0 +1,1174 @@
+# Heart rate analysis
+
+This tutorial shows how to extract heart rate estimates using photoplethysmography (PPG) data and accelerometer data. The pipeline consists of a stepwise approach to determine signal quality, assessing both PPG morphology and accounting for periodic artifacts using the accelerometer. Based on the signal quality, we extract high-quality segments and estimate the heart rate for every 2 s using the smoothed pseudo Wigner-Ville Distribution.
+
+In this tutorial, we use two days of data from a participant of the Personalized Parkinson Project to demonstrate the functionalities. Since `ParaDigMa` expects contiguous time series, the collected data was stored in two segments each with contiguous timestamps. Per segment, we load the data and perform the following steps:
+1. Preprocess the time series data
+2. Extract signal quality features
+3. Signal quality classification
+4. Heart rate estimation
+
+We then combine the output of the different segments for the final step:
+
+5. Heart rate aggregation
+
+## Load data
+
+This pipeline requires accelerometer and PPG data to run. Here, we start by loading a single contiguous time series (segment), for which we continue running steps 1-4. [Below](#multiple_segments_cell) we show how to run these steps for multiple segments. The channel `green` represents the values obtained with PPG using green light.
+
+In this example we use the interally developed `TSDF` ([documentation](https://biomarkersparkinson.github.io/tsdf/)) to load and store data [[1](https://arxiv.org/abs/2211.11294)]. However, we are aware that there are other common data formats. For example, the following functions can be used depending on the file extension of the data:
+- _.csv_: `pandas.read_csv()` ([documentation](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html))
+- _.json_: `json.load()` ([documentation](https://docs.python.org/3/library/json.html#json.load))
+
+
+
+```python
+from pathlib import Path
+from paradigma.util import load_tsdf_dataframe
+
+# Set the path to where the prepared data is saved and load the data.
+# Note: the test data is stored in TSDF, but you can load your data in your own way
+path_to_prepared_data =  Path('../../example_data')
+
+ppg_prefix = 'ppg'
+imu_prefix = 'imu'
+
+segment_nr = '0001' 
+
+df_ppg, metadata_time_ppg, metadata_values_ppg = load_tsdf_dataframe(
+    path_to_data=path_to_prepared_data / ppg_prefix, 
+    prefix=f'PPG_segment{segment_nr}'
+)
+df_imu, metadata_time_imu, metadata_values_imu = load_tsdf_dataframe(
+    path_to_data=path_to_prepared_data / imu_prefix, 
+    prefix=f'IMU_segment{segment_nr}'
+)
+
+# Drop the gyroscope columns from the IMU data
+cols_to_drop = df_imu.filter(regex='^gyroscope_').columns
+df_acc = df_imu.drop(cols_to_drop, axis=1)
+
+display(df_ppg, df_acc)
+```
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>green</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.00000</td>
+      <td>262316</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>0.03340</td>
+      <td>262320</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>0.06680</td>
+      <td>262446</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>0.10020</td>
+      <td>262770</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>0.13360</td>
+      <td>262623</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>1029370</th>
+      <td>34339.49720</td>
+      <td>1049632</td>
+    </tr>
+    <tr>
+      <th>1029371</th>
+      <td>34339.53056</td>
+      <td>1049632</td>
+    </tr>
+    <tr>
+      <th>1029372</th>
+      <td>34339.56392</td>
+      <td>1049632</td>
+    </tr>
+    <tr>
+      <th>1029373</th>
+      <td>34339.59728</td>
+      <td>1049632</td>
+    </tr>
+    <tr>
+      <th>1029374</th>
+      <td>34339.63064</td>
+      <td>1020788</td>
+    </tr>
+  </tbody>
+</table>
+<p>1029375 rows × 2 columns</p>
+</div>
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>accelerometer_x</th>
+      <th>accelerometer_y</th>
+      <th>accelerometer_z</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.000000</td>
+      <td>-0.474641</td>
+      <td>-0.379426</td>
+      <td>0.770335</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>0.009933</td>
+      <td>-0.472727</td>
+      <td>-0.378947</td>
+      <td>0.765072</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>0.019867</td>
+      <td>-0.471770</td>
+      <td>-0.375598</td>
+      <td>0.766986</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>0.029800</td>
+      <td>-0.472727</td>
+      <td>-0.375598</td>
+      <td>0.770335</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>0.039733</td>
+      <td>-0.475120</td>
+      <td>-0.379426</td>
+      <td>0.772249</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>3455326</th>
+      <td>34339.561333</td>
+      <td>-0.257895</td>
+      <td>-0.319139</td>
+      <td>-0.761244</td>
+    </tr>
+    <tr>
+      <th>3455327</th>
+      <td>34339.571267</td>
+      <td>-0.555502</td>
+      <td>-0.153110</td>
+      <td>-0.671292</td>
+    </tr>
+    <tr>
+      <th>3455328</th>
+      <td>34339.581200</td>
+      <td>-0.286124</td>
+      <td>-0.263636</td>
+      <td>-0.981340</td>
+    </tr>
+    <tr>
+      <th>3455329</th>
+      <td>34339.591133</td>
+      <td>-0.232536</td>
+      <td>-0.161722</td>
+      <td>-0.832536</td>
+    </tr>
+    <tr>
+      <th>3455330</th>
+      <td>34339.601067</td>
+      <td>0.180383</td>
+      <td>-0.368421</td>
+      <td>-1.525837</td>
+    </tr>
+  </tbody>
+</table>
+<p>3455331 rows × 4 columns</p>
+</div>
+
+
+## Step 1: Preprocess data
+
+The first step after loading the data is preprocessing using the [preprocess_ppg_data](https://github.com/biomarkersParkinson/paradigma/blob/main/src/paradigma/preprocessing.py#:~:text=preprocess_ppg_data). This begins by isolating segments containing both PPG and IMU data, discarding portions where one modality (e.g., PPG) extends beyond the other, such as when the PPG recording is longer than the accelerometer data. This functionality requires the starting times (`metadata_time_ppg.start_iso8601` and `metadata_time_imu.start_iso8601`) in iso8601 format as inputs. After this step, the preprocess_ppg_data function resamples the PPG and accelerometer data to uniformly distributed timestamps, addressing the fixed but non-uniform sampling rates of the sensors. After this, a bandpass Butterworth filter (4th-order, bandpass frequencies: 0.4--3.5 Hz) is applied to the PPG signal, while a high-pass Butterworth filter (4th-order, cut-off frequency: 0.2 Hz) is applied to the accelerometer data.
+
+Note: the printed shapes are (rows, columns) with each row corresponding to a single data point and each column representing a data column (e.g.time). The number of rows of the overlapping segments of PPG and accelerometer are not the same due to sampling differences (other sensors and possibly other sampling frequencies).
+
+
+```python
+from paradigma.config import PPGConfig, IMUConfig
+from paradigma.preprocessing import preprocess_ppg_data
+
+ppg_config = PPGConfig()
+imu_config = IMUConfig()
+
+print(f"Original data shapes:\n- PPG data: {df_ppg.shape}\n- Accelerometer data: {df_imu.shape}")
+df_ppg_proc, df_acc_proc = preprocess_ppg_data(
+    df_ppg=df_ppg, 
+    df_acc=df_acc, 
+    ppg_config=ppg_config, 
+    imu_config=imu_config, 
+    start_time_ppg=metadata_time_ppg.start_iso8601,
+    start_time_imu=metadata_time_imu.start_iso8601
+)
+
+print(f"Overlapping preprocessed data shapes:\n- PPG data: {df_ppg_proc.shape}\n- Accelerometer data: {df_acc_proc.shape}")
+display(df_ppg_proc, df_acc_proc)
+```
+
+    Original data shapes:
+    - PPG data: (1029375, 2)
+    - Accelerometer data: (3455331, 7)
+    Overlapping preprocessed data shapes:
+    - PPG data: (1030188, 2)
+    - Accelerometer data: (3433961, 4)
+    
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>green</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.000000</td>
+      <td>-26.315811</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>0.033333</td>
+      <td>91.335299</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>0.066667</td>
+      <td>181.603416</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>0.100000</td>
+      <td>225.760466</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>0.133333</td>
+      <td>219.937282</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>1030183</th>
+      <td>34339.433333</td>
+      <td>224556.234611</td>
+    </tr>
+    <tr>
+      <th>1030184</th>
+      <td>34339.466667</td>
+      <td>210075.529517</td>
+    </tr>
+    <tr>
+      <th>1030185</th>
+      <td>34339.500000</td>
+      <td>163811.629247</td>
+    </tr>
+    <tr>
+      <th>1030186</th>
+      <td>34339.533333</td>
+      <td>94537.897763</td>
+    </tr>
+    <tr>
+      <th>1030187</th>
+      <td>34339.566667</td>
+      <td>12915.304284</td>
+    </tr>
+  </tbody>
+</table>
+<p>1030188 rows × 2 columns</p>
+</div>
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>accelerometer_x</th>
+      <th>accelerometer_y</th>
+      <th>accelerometer_z</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.00</td>
+      <td>-0.002324</td>
+      <td>-0.001442</td>
+      <td>-0.002116</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>0.01</td>
+      <td>-0.000390</td>
+      <td>-0.000914</td>
+      <td>-0.007396</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>0.02</td>
+      <td>0.000567</td>
+      <td>0.002474</td>
+      <td>-0.005445</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>0.03</td>
+      <td>-0.000425</td>
+      <td>0.002414</td>
+      <td>-0.002099</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>0.04</td>
+      <td>-0.002807</td>
+      <td>-0.001408</td>
+      <td>-0.000218</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>3433956</th>
+      <td>34339.56</td>
+      <td>-0.402941</td>
+      <td>0.038710</td>
+      <td>0.461449</td>
+    </tr>
+    <tr>
+      <th>3433957</th>
+      <td>34339.57</td>
+      <td>-0.659832</td>
+      <td>0.098696</td>
+      <td>0.817136</td>
+    </tr>
+    <tr>
+      <th>3433958</th>
+      <td>34339.58</td>
+      <td>-0.464138</td>
+      <td>0.033607</td>
+      <td>0.471552</td>
+    </tr>
+    <tr>
+      <th>3433959</th>
+      <td>34339.59</td>
+      <td>-0.389065</td>
+      <td>0.108485</td>
+      <td>0.622471</td>
+    </tr>
+    <tr>
+      <th>3433960</th>
+      <td>34339.60</td>
+      <td>-0.082625</td>
+      <td>-0.014490</td>
+      <td>0.119875</td>
+    </tr>
+  </tbody>
+</table>
+<p>3433961 rows × 4 columns</p>
+</div>
+
+
+## Step 2: Extract signal quality features
+
+The preprocessed data (PPG & accelerometer) is windowed into overlapping windows of length `ppg_config.window_length_s` with a window step of `ppg_config.window_step_length_s`. From the PPG windows 10 time- and frequency domain features are extracted to assess PPG morphology and from the accelerometer windows one relative power feature is calculated to assess periodic motion artifacts.
+
+The detailed steps are encapsulated in `extract_signal_quality_features` (documentation can be found [here](https://github.com/biomarkersParkinson/paradigma/blob/main/src/paradigma/pipelines/heart_rate_pipeline.py#:~:text=extract_signal_quality_features)).
+
+
+```python
+from paradigma.config import HeartRateConfig
+from paradigma.pipelines.heart_rate_pipeline import extract_signal_quality_features
+
+ppg_config = HeartRateConfig('ppg')
+acc_config = HeartRateConfig('imu')
+
+print("The default window length for the signal quality feature extraction is set to", ppg_config.window_length_s, "seconds.")
+print("The default step size for the signal quality feature extraction is set to", ppg_config.window_step_length_s, "seconds.")
+
+df_features = extract_signal_quality_features(
+    df_ppg=df_ppg_proc,
+    df_acc=df_acc_proc,
+    ppg_config=ppg_config, 
+    acc_config=acc_config, 
+)
+
+df_features
+
+```
+
+    The default window length for the signal quality feature extraction is set to 6 seconds.
+    The default step size for the signal quality feature extraction is set to 1 seconds.
+    
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>var</th>
+      <th>mean</th>
+      <th>median</th>
+      <th>kurtosis</th>
+      <th>skewness</th>
+      <th>signal_to_noise</th>
+      <th>auto_corr</th>
+      <th>f_dom</th>
+      <th>rel_power</th>
+      <th>spectral_entropy</th>
+      <th>acc_power_ratio</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.0</td>
+      <td>1.145652e+05</td>
+      <td>282.401234</td>
+      <td>238.829637</td>
+      <td>2.170853</td>
+      <td>0.107401</td>
+      <td>3.320049</td>
+      <td>0.544165</td>
+      <td>0.585938</td>
+      <td>0.138454</td>
+      <td>0.516336</td>
+      <td>0.026409</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>1.0</td>
+      <td>1.102401e+05</td>
+      <td>271.582177</td>
+      <td>236.891936</td>
+      <td>2.251393</td>
+      <td>-0.029309</td>
+      <td>3.041878</td>
+      <td>0.491829</td>
+      <td>0.585938</td>
+      <td>0.160433</td>
+      <td>0.511626</td>
+      <td>0.023402</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>2.0</td>
+      <td>1.061479e+05</td>
+      <td>262.348604</td>
+      <td>225.915756</td>
+      <td>2.415221</td>
+      <td>0.216631</td>
+      <td>2.818552</td>
+      <td>0.469092</td>
+      <td>0.585938</td>
+      <td>0.167007</td>
+      <td>0.525025</td>
+      <td>0.028592</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>3.0</td>
+      <td>9.514719e+04</td>
+      <td>245.089445</td>
+      <td>203.417715</td>
+      <td>2.481465</td>
+      <td>0.110420</td>
+      <td>2.677071</td>
+      <td>0.415071</td>
+      <td>0.585938</td>
+      <td>0.170626</td>
+      <td>0.550495</td>
+      <td>0.019296</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>4.0</td>
+      <td>7.393010e+04</td>
+      <td>218.379138</td>
+      <td>187.583267</td>
+      <td>2.405921</td>
+      <td>0.084566</td>
+      <td>2.796140</td>
+      <td>0.338369</td>
+      <td>0.585938</td>
+      <td>0.121113</td>
+      <td>0.595214</td>
+      <td>0.020083</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>34329</th>
+      <td>34329.0</td>
+      <td>8.176078e+06</td>
+      <td>1613.021494</td>
+      <td>438.201240</td>
+      <td>6.122772</td>
+      <td>-1.792336</td>
+      <td>1.378694</td>
+      <td>0.104389</td>
+      <td>0.351562</td>
+      <td>0.046616</td>
+      <td>0.356027</td>
+      <td>0.110219</td>
+    </tr>
+    <tr>
+      <th>34330</th>
+      <td>34330.0</td>
+      <td>3.512188e+07</td>
+      <td>3307.888927</td>
+      <td>1069.775894</td>
+      <td>8.160698</td>
+      <td>1.746472</td>
+      <td>1.442643</td>
+      <td>0.142226</td>
+      <td>0.351562</td>
+      <td>0.049424</td>
+      <td>0.371163</td>
+      <td>0.178742</td>
+    </tr>
+    <tr>
+      <th>34331</th>
+      <td>34331.0</td>
+      <td>1.181350e+08</td>
+      <td>6648.535487</td>
+      <td>2743.478312</td>
+      <td>5.654373</td>
+      <td>0.018587</td>
+      <td>1.558314</td>
+      <td>0.136803</td>
+      <td>0.351562</td>
+      <td>0.048211</td>
+      <td>0.366386</td>
+      <td>0.153351</td>
+    </tr>
+    <tr>
+      <th>34332</th>
+      <td>34332.0</td>
+      <td>1.252829e+09</td>
+      <td>20165.525309</td>
+      <td>6452.244225</td>
+      <td>6.805051</td>
+      <td>-1.222184</td>
+      <td>1.310088</td>
+      <td>0.666123</td>
+      <td>0.351562</td>
+      <td>0.037812</td>
+      <td>0.359105</td>
+      <td>0.154910</td>
+    </tr>
+    <tr>
+      <th>34333</th>
+      <td>34333.0</td>
+      <td>1.008217e+10</td>
+      <td>42271.328020</td>
+      <td>12552.656437</td>
+      <td>23.756877</td>
+      <td>4.167326</td>
+      <td>1.212179</td>
+      <td>0.044647</td>
+      <td>0.585938</td>
+      <td>0.113283</td>
+      <td>0.632749</td>
+      <td>0.093221</td>
+    </tr>
+  </tbody>
+</table>
+<p>34334 rows × 12 columns</p>
+</div>
+
+
+
+## Step 3: Signal quality classification
+
+A trained logistic classifier is used to predict PPG signal quality and returns the `pred_sqa_proba`, which is the posterior probability of a PPG window to look like the typical PPG morphology (higher probability indicates toward the typical PPG morphology). The relative power feature from the accelerometer is compared to a threshold for periodic artifacts and therefore `pred_sqa_acc_label` is used to return a label indicating predicted periodic motion artifacts (label 0) or no periodic motion artifacts (label 1).
+
+The classification step is implemented in `signal_quality_classification` (documentation can be found [here](https://github.com/biomarkersParkinson/paradigma/blob/main/src/paradigma/pipelines/heart_rate_pipeline.py#:~:text=signal_quality_classification)).
+
+
+```python
+from importlib.resources import files
+from paradigma.pipelines.heart_rate_pipeline import signal_quality_classification
+
+ppg_quality_classifier_package_filename = 'ppg_quality_clf_package.pkl'
+full_path_to_classifier_package = files('paradigma') / 'assets' / ppg_quality_classifier_package_filename
+
+config = HeartRateConfig()
+
+df_sqa = signal_quality_classification(
+    df=df_features, 
+    config=config, 
+    full_path_to_classifier_package=full_path_to_classifier_package
+)
+
+df_sqa
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>pred_sqa_proba</th>
+      <th>pred_sqa_acc_label</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.0</td>
+      <td>1.121315e-02</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>1.0</td>
+      <td>7.126135e-03</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>2.0</td>
+      <td>7.017555e-03</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>3.0</td>
+      <td>4.134224e-03</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>4.0</td>
+      <td>9.195340e-04</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>34329</th>
+      <td>34329.0</td>
+      <td>1.782669e-08</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <th>34330</th>
+      <td>34330.0</td>
+      <td>2.078262e-06</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>34331</th>
+      <td>34331.0</td>
+      <td>1.190223e-07</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>34332</th>
+      <td>34332.0</td>
+      <td>1.383614e-08</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>34333</th>
+      <td>34333.0</td>
+      <td>7.587516e-07</td>
+      <td>1</td>
+    </tr>
+  </tbody>
+</table>
+<p>34334 rows × 3 columns</p>
+</div>
+
+
+
+#### Store as TSDF
+The predicted probabilities (and optionally other features) can be stored and loaded in TSDF as demonstrated below. 
+
+
+```python
+import tsdf
+from paradigma.util import write_df_data
+
+# Set 'path_to_data' to the directory where you want to save the data
+metadata_time_store = tsdf.TSDFMetadata(metadata_time_ppg.get_plain_tsdf_dict_copy(), path_to_prepared_data)
+metadata_values_store = tsdf.TSDFMetadata(metadata_values_ppg.get_plain_tsdf_dict_copy(), path_to_prepared_data)
+
+# Select the columns to be saved 
+metadata_time_store.channels = ['time']
+metadata_values_store.channels = ['pred_sqa_proba', 'pred_sqa_acc_label']
+
+# Set the units
+metadata_time_store.units = ['Relative seconds']
+metadata_values_store.units = ['Unitless', 'Unitless']
+metadata_time_store.data_type = float
+metadata_values_store.data_type = float
+
+# Set the filenames
+meta_store_filename = f'segment{segment_nr}_meta.json'
+values_store_filename = meta_store_filename.replace('_meta.json', '_values.bin')
+time_store_filename = meta_store_filename.replace('_meta.json', '_time.bin')
+
+metadata_values_store.file_name = values_store_filename
+metadata_time_store.file_name = time_store_filename
+
+write_df_data(metadata_time_store, metadata_values_store, path_to_prepared_data, meta_store_filename, df_sqa)
+```
+
+
+```python
+df_sqa, _, _ = load_tsdf_dataframe(path_to_prepared_data, prefix=f'segment{segment_nr}')
+df_sqa.head()
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>pred_sqa_proba</th>
+      <th>pred_sqa_acc_label</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.0</td>
+      <td>0.011213</td>
+      <td>1.0</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>1.0</td>
+      <td>0.007126</td>
+      <td>1.0</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>2.0</td>
+      <td>0.007018</td>
+      <td>1.0</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>3.0</td>
+      <td>0.004134</td>
+      <td>1.0</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>4.0</td>
+      <td>0.000920</td>
+      <td>1.0</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+
+
+## Step 4: Heart rate estimation
+
+For heart rate estimation, we extract segments of `config.tfd_length` using [estimate_heart_rate](https://github.com/biomarkersParkinson/paradigma/blob/main/src/paradigma/pipelines/heart_rate_pipeline.py#:~:text=estimate_heart_rate). We calculate the smoothed-pseudo Wigner-Ville Distribution (SPWVD) to obtain the frequency content of the PPG signal over time. We extract for every timestamp in the SPWVD the frequency with the highest power. For every non-overlapping 2 s window we average the corresponding frequencies to obtain a heart rate per window.
+
+Note: for the test data we set the tfd_length to 10 s instead of the default of 30 s, because the small PPP test data doesn't have 30 s of consecutive high-quality PPG data.
+
+
+```python
+from paradigma.pipelines.heart_rate_pipeline import estimate_heart_rate
+
+print("The standard default minimal window length for the heart rate extraction is set to", config.tfd_length, "seconds.")
+# set the minimal window length for the heart rate extraction to 10 seconds instead of default of 30 seconds.
+#config.set_tfd_length(10)       
+
+df_hr = estimate_heart_rate(
+    df_sqa=df_sqa, 
+    df_ppg_preprocessed=df_ppg_proc, 
+    config=config
+)
+
+df_hr
+```
+
+    The standard default minimal window length for the heart rate extraction is set to 30 seconds.
+    
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>heart_rate</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>47.0</td>
+      <td>80.372915</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>49.0</td>
+      <td>79.769382</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>51.0</td>
+      <td>79.136408</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>53.0</td>
+      <td>78.606477</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>55.0</td>
+      <td>77.870461</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>825</th>
+      <td>32876.0</td>
+      <td>78.220133</td>
+    </tr>
+    <tr>
+      <th>826</th>
+      <td>32878.0</td>
+      <td>78.047301</td>
+    </tr>
+    <tr>
+      <th>827</th>
+      <td>32880.0</td>
+      <td>78.047301</td>
+    </tr>
+    <tr>
+      <th>828</th>
+      <td>32882.0</td>
+      <td>78.238326</td>
+    </tr>
+    <tr>
+      <th>829</th>
+      <td>32884.0</td>
+      <td>78.556701</td>
+    </tr>
+  </tbody>
+</table>
+<p>830 rows × 2 columns</p>
+</div>
+
+
+
+### Run steps 1 - 4 for multiple segments <a id='multiple_segments_cell'></a>
+
+If your data is also stored in multiple segments, you can modify `segments` in the cell below to a list of the filenames of your respective segmented data.
+
+
+```python
+import pandas as pd
+from pathlib import Path
+from importlib.resources import files
+
+from paradigma.util import load_tsdf_dataframe
+from paradigma.config import PPGConfig, IMUConfig, HeartRateConfig
+from paradigma.preprocessing import preprocess_ppg_data
+from paradigma.pipelines.heart_rate_pipeline import extract_signal_quality_features, signal_quality_classification, estimate_heart_rate
+
+# Set the path to where the prepared data is saved
+path_to_prepared_data =  Path('../../example_data')
+
+ppg_prefix = 'ppg'
+imu_prefix = 'imu'
+
+# Set the path to the classifier package
+ppg_quality_classifier_package_filename = 'ppg_quality_clf_package.pkl'
+full_path_to_classifier_package = files('paradigma') / 'assets' / ppg_quality_classifier_package_filename
+
+# Create a list of dataframes to store the estimated heart rates of all segments
+list_df_hr = []
+
+segments = ['0001', '0002'] # list with all available segments
+
+for segment_nr in segments:
+    
+    # Load the data
+    df_ppg, metadata_time_ppg, _ = load_tsdf_dataframe(
+        path_to_data=path_to_prepared_data / ppg_prefix, 
+        prefix=f'PPG_segment{segment_nr}'
+    )
+    df_imu, metadata_time_imu, _ = load_tsdf_dataframe(
+        path_to_data=path_to_prepared_data / imu_prefix, 
+        prefix=f'IMU_segment{segment_nr}'   
+    )
+
+    # Drop the gyroscope columns from the IMU data
+    cols_to_drop = df_imu.filter(regex='^gyroscope_').columns
+    df_acc = df_imu.drop(cols_to_drop, axis=1)
+
+    # 1: Preprocess the data
+
+    ppg_config = PPGConfig()
+    imu_config = IMUConfig()
+
+    df_ppg_proc, df_acc_proc = preprocess_ppg_data(
+        df_ppg=df_ppg, 
+        df_acc=df_acc, 
+        ppg_config=ppg_config, 
+        imu_config=imu_config, 
+        start_time_ppg=metadata_time_ppg.start_iso8601,
+        start_time_imu=metadata_time_imu.start_iso8601
+    )
+
+    # 2: Extract signal quality features
+    ppg_config = HeartRateConfig('ppg')
+    acc_config = HeartRateConfig('imu')
+
+    df_features = extract_signal_quality_features(
+        df_ppg=df_ppg_proc,
+        df_acc=df_acc_proc,
+        ppg_config=ppg_config, 
+        acc_config=acc_config, 
+    )
+    
+    # 3: Signal quality classification
+    config = HeartRateConfig()
+
+    df_sqa = signal_quality_classification(
+        df=df_features, 
+        config=config, 
+        full_path_to_classifier_package=full_path_to_classifier_package
+    )
+
+    # 4: Estimate heart rate
+    df_hr = estimate_heart_rate(
+        df_sqa=df_sqa, 
+        df_ppg_preprocessed=df_ppg_proc, 
+        config=config
+    )
+
+    # Add the hr estimations of the current segment to the list
+    df_hr['segment_nr'] = segment_nr
+    list_df_hr.append(df_hr)
+
+df_hr = pd.concat(list_df_hr, ignore_index=True)
+```
+
+## Step 5: Heart rate aggregation
+
+The final step is to aggregate all 2 s heart rate estimates using [aggregate_heart_rate](https://github.com/biomarkersParkinson/paradigma/blob/main/src/paradigma/pipelines/heart_rate_pipeline.py#:~:text=aggregate_heart_rate). In the current example, the mode and 99th percentile are calculated. We hypothesize that the mode gives representation of the resting heart rate while the 99th percentile indicates the maximum heart rate. In Parkinson's disease, we expect that these two measures could reflect autonomic (dys)functioning. The `nr_hr_est` in the metadata indicates based on how many 2 s windows these aggregates are determined.
+
+
+```python
+import pprint
+from paradigma.pipelines.heart_rate_pipeline import aggregate_heart_rate
+
+hr_values = df_hr['heart_rate'].values
+df_hr_agg = aggregate_heart_rate(
+    hr_values=hr_values, 
+    aggregates = ['mode', '99p']
+)
+
+pprint.pprint(df_hr_agg)
+```
+
+    {'hr_aggregates': {'99p_heart_rate': 85.77263444520081,
+                       'mode_heart_rate': 63.59175662414131},
+     'metadata': {'nr_hr_est': 8684}}
+    

--- a/docs/tutorials/_static/tremor_analysis.md
+++ b/docs/tutorials/_static/tremor_analysis.md
@@ -1,0 +1,1032 @@
+# Tremor analysis
+
+This tutorial shows how to run the tremor pipeline to obtain aggregated tremor measures from gyroscope sensor data. Before following along, make sure all data preparation steps have been followed in the data preparation tutorial. 
+
+In this tutorial, we use two days of data from a participant of the Personalized Parkinson Project to demonstrate the functionalities. Since `ParaDigMa` expects contiguous time series, the collected data was stored in two segments each with contiguous timestamps. Per segment, we load the data and perform the following steps:
+1. Preprocess the time series data
+2. Extract tremor features
+3. Detect tremor
+4. Quantify tremor
+
+We then combine the output of the different segments for the final step:
+
+5. Compute aggregated tremor measures
+
+## Load example data
+
+Here, we start by loading a single contiguous time series (segment), for which we continue running steps 1-3. [Below](#multiple_segments_cell) we show how to run these steps for multiple segments.
+
+We use the interally developed `TSDF` ([documentation](https://biomarkersparkinson.github.io/tsdf/)) to load and store data [[1](https://arxiv.org/abs/2211.11294)]. Depending on the file extension of your time series data, examples of other Python functions for loading the data into memory include:
+- _.csv_: `pandas.read_csv()` ([documentation](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html))
+- _.json_: `json.load()` ([documentation](https://docs.python.org/3/library/json.html#json.load))
+
+
+```python
+from pathlib import Path
+from paradigma.util import load_tsdf_dataframe
+
+# Set the path to where the prepared data is saved and load the data.
+# Note: the test data is stored in TSDF, but you can load your data in your own way
+path_to_data =  Path('../../example_data')
+path_to_prepared_data = path_to_data / 'imu'
+
+segment_nr  = '0001' 
+
+df_data, metadata_time, metadata_values = load_tsdf_dataframe(path_to_prepared_data, prefix=f'IMU_segment{segment_nr}')
+
+df_data
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>accelerometer_x</th>
+      <th>accelerometer_y</th>
+      <th>accelerometer_z</th>
+      <th>gyroscope_x</th>
+      <th>gyroscope_y</th>
+      <th>gyroscope_z</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.000000</td>
+      <td>-0.474641</td>
+      <td>-0.379426</td>
+      <td>0.770335</td>
+      <td>0.000000</td>
+      <td>1.402439</td>
+      <td>0.243902</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>0.009933</td>
+      <td>-0.472727</td>
+      <td>-0.378947</td>
+      <td>0.765072</td>
+      <td>0.426829</td>
+      <td>0.670732</td>
+      <td>-0.121951</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>0.019867</td>
+      <td>-0.471770</td>
+      <td>-0.375598</td>
+      <td>0.766986</td>
+      <td>1.158537</td>
+      <td>-0.060976</td>
+      <td>-0.304878</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>0.029800</td>
+      <td>-0.472727</td>
+      <td>-0.375598</td>
+      <td>0.770335</td>
+      <td>1.158537</td>
+      <td>-0.548780</td>
+      <td>-0.548780</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>0.039733</td>
+      <td>-0.475120</td>
+      <td>-0.379426</td>
+      <td>0.772249</td>
+      <td>0.670732</td>
+      <td>-0.609756</td>
+      <td>-0.731707</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>3455326</th>
+      <td>34339.561333</td>
+      <td>-0.257895</td>
+      <td>-0.319139</td>
+      <td>-0.761244</td>
+      <td>159.329269</td>
+      <td>14.634146</td>
+      <td>-28.658537</td>
+    </tr>
+    <tr>
+      <th>3455327</th>
+      <td>34339.571267</td>
+      <td>-0.555502</td>
+      <td>-0.153110</td>
+      <td>-0.671292</td>
+      <td>125.060976</td>
+      <td>-213.902440</td>
+      <td>-19.329268</td>
+    </tr>
+    <tr>
+      <th>3455328</th>
+      <td>34339.581200</td>
+      <td>-0.286124</td>
+      <td>-0.263636</td>
+      <td>-0.981340</td>
+      <td>158.658537</td>
+      <td>-328.170733</td>
+      <td>-3.170732</td>
+    </tr>
+    <tr>
+      <th>3455329</th>
+      <td>34339.591133</td>
+      <td>-0.232536</td>
+      <td>-0.161722</td>
+      <td>-0.832536</td>
+      <td>288.841465</td>
+      <td>-281.707318</td>
+      <td>17.073171</td>
+    </tr>
+    <tr>
+      <th>3455330</th>
+      <td>34339.601067</td>
+      <td>0.180383</td>
+      <td>-0.368421</td>
+      <td>-1.525837</td>
+      <td>376.219514</td>
+      <td>-140.853659</td>
+      <td>37.256098</td>
+    </tr>
+  </tbody>
+</table>
+<p>3455331 rows × 7 columns</p>
+</div>
+
+
+
+## Step 1: Preprocess data
+
+IMU sensors collect data at a fixed sampling frequency, but the sampling rate is not uniform, causing variation in time differences between timestamps. The [preprocess_imu_data](https://github.com/biomarkersParkinson/paradigma/blob/main/src/paradigma/preprocessing.py#:~:text=preprocess_imu_data) function therefore resamples the timestamps to be uniformly distributed, and then interpolates IMU values at these new timestamps using the original timestamps and corresponding IMU values. By setting `sensor` to 'gyroscope', only gyroscope data is preprocessed and the accelerometer data is removed from the dataframe. Also a `watch_side` should be provided, although for the tremor analysis it does not matter whether this is the correct side since the tremor features are not influenced by the gyroscope axes orientation.
+
+
+```python
+from paradigma.config import IMUConfig
+from paradigma.preprocessing import preprocess_imu_data
+
+config = IMUConfig()
+print(f'The data is resampled to {config.sampling_frequency} Hz.')
+
+df_preprocessed_data = preprocess_imu_data(df_data, config, sensor='gyroscope', watch_side='left')
+
+df_preprocessed_data
+```
+
+    The data is resampled to 100 Hz.
+    
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>gyroscope_x</th>
+      <th>gyroscope_y</th>
+      <th>gyroscope_z</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.00</td>
+      <td>0.000000</td>
+      <td>1.402439</td>
+      <td>0.243902</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>0.01</td>
+      <td>0.432231</td>
+      <td>0.665526</td>
+      <td>-0.123434</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>0.02</td>
+      <td>1.164277</td>
+      <td>-0.069584</td>
+      <td>-0.307536</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>0.03</td>
+      <td>1.151432</td>
+      <td>-0.554928</td>
+      <td>-0.554223</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>0.04</td>
+      <td>0.657189</td>
+      <td>-0.603207</td>
+      <td>-0.731570</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>3433956</th>
+      <td>34339.56</td>
+      <td>130.392434</td>
+      <td>29.491627</td>
+      <td>-26.868202</td>
+    </tr>
+    <tr>
+      <th>3433957</th>
+      <td>34339.57</td>
+      <td>135.771133</td>
+      <td>-184.515525</td>
+      <td>-21.544211</td>
+    </tr>
+    <tr>
+      <th>3433958</th>
+      <td>34339.58</td>
+      <td>146.364103</td>
+      <td>-324.248909</td>
+      <td>-5.248641</td>
+    </tr>
+    <tr>
+      <th>3433959</th>
+      <td>34339.59</td>
+      <td>273.675024</td>
+      <td>-293.011330</td>
+      <td>14.618256</td>
+    </tr>
+    <tr>
+      <th>3433960</th>
+      <td>34339.60</td>
+      <td>372.878731</td>
+      <td>-158.516265</td>
+      <td>35.330770</td>
+    </tr>
+  </tbody>
+</table>
+<p>3433961 rows × 4 columns</p>
+</div>
+
+
+
+## Step 2: Extract tremor features
+
+The function [`extract_tremor_features`](https://github.com/biomarkersParkinson/paradigma/blob/main/src/paradigma/pipelines/tremor_pipeline.py#:~:text=extract_tremor_features) extracts windows from the preprocessed gyroscope data using non-overlapping windows of length `config.window_length_s`. Next, from these windows the tremor features are extracted: 12 mel-frequency cepstral coefficients (MFCCs), frequency of the peak in the power spectral density, power below tremor (0.5 - 3 Hz), and power around the tremor peak. The latter is not used for tremor detection, but stored for tremor quantification in Step 4.
+
+
+```python
+from paradigma.config import TremorConfig
+from paradigma.pipelines.tremor_pipeline import extract_tremor_features
+
+config = TremorConfig(step='features')
+print(f'The window length is {config.window_length_s} seconds')
+
+df_features = extract_tremor_features(df_preprocessed_data, config)
+
+df_features
+```
+
+    The window length is 4 seconds
+    
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>mfcc_1</th>
+      <th>mfcc_2</th>
+      <th>mfcc_3</th>
+      <th>mfcc_4</th>
+      <th>mfcc_5</th>
+      <th>mfcc_6</th>
+      <th>mfcc_7</th>
+      <th>mfcc_8</th>
+      <th>mfcc_9</th>
+      <th>mfcc_10</th>
+      <th>mfcc_11</th>
+      <th>mfcc_12</th>
+      <th>freq_peak</th>
+      <th>below_tremor_power</th>
+      <th>tremor_power</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.0</td>
+      <td>5.323582</td>
+      <td>1.179579</td>
+      <td>-0.498552</td>
+      <td>-0.149152</td>
+      <td>-0.063535</td>
+      <td>-0.132090</td>
+      <td>-0.112380</td>
+      <td>-0.044326</td>
+      <td>-0.025917</td>
+      <td>0.116045</td>
+      <td>0.169869</td>
+      <td>0.213884</td>
+      <td>3.75</td>
+      <td>0.082219</td>
+      <td>0.471588</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>4.0</td>
+      <td>5.333162</td>
+      <td>1.205712</td>
+      <td>-0.607844</td>
+      <td>-0.138371</td>
+      <td>-0.039518</td>
+      <td>-0.137703</td>
+      <td>-0.069552</td>
+      <td>-0.008029</td>
+      <td>-0.087711</td>
+      <td>0.089844</td>
+      <td>0.152380</td>
+      <td>0.195165</td>
+      <td>3.75</td>
+      <td>0.071260</td>
+      <td>0.327252</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>8.0</td>
+      <td>5.180974</td>
+      <td>1.039548</td>
+      <td>-0.627100</td>
+      <td>-0.054816</td>
+      <td>-0.016767</td>
+      <td>-0.044817</td>
+      <td>0.079859</td>
+      <td>-0.023155</td>
+      <td>0.024729</td>
+      <td>0.104989</td>
+      <td>0.126502</td>
+      <td>0.192319</td>
+      <td>7.75</td>
+      <td>0.097961</td>
+      <td>0.114138</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>12.0</td>
+      <td>5.290298</td>
+      <td>1.183957</td>
+      <td>-0.627651</td>
+      <td>-0.027235</td>
+      <td>0.095184</td>
+      <td>-0.050455</td>
+      <td>-0.024654</td>
+      <td>0.029754</td>
+      <td>-0.007459</td>
+      <td>0.125700</td>
+      <td>0.146895</td>
+      <td>0.220589</td>
+      <td>7.75</td>
+      <td>0.193237</td>
+      <td>0.180988</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>16.0</td>
+      <td>5.128074</td>
+      <td>1.066869</td>
+      <td>-0.622282</td>
+      <td>0.038557</td>
+      <td>-0.034719</td>
+      <td>0.045109</td>
+      <td>0.076679</td>
+      <td>0.057267</td>
+      <td>-0.024619</td>
+      <td>0.131755</td>
+      <td>0.177849</td>
+      <td>0.149686</td>
+      <td>7.75</td>
+      <td>0.156469</td>
+      <td>0.090009</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>8579</th>
+      <td>34316.0</td>
+      <td>7.071408</td>
+      <td>-0.376556</td>
+      <td>0.272322</td>
+      <td>0.068750</td>
+      <td>0.051588</td>
+      <td>0.102012</td>
+      <td>0.055017</td>
+      <td>0.115942</td>
+      <td>0.012746</td>
+      <td>0.117970</td>
+      <td>0.073279</td>
+      <td>0.057367</td>
+      <td>13.50</td>
+      <td>48.930380</td>
+      <td>91.971686</td>
+    </tr>
+    <tr>
+      <th>8580</th>
+      <td>34320.0</td>
+      <td>1.917642</td>
+      <td>0.307927</td>
+      <td>0.142330</td>
+      <td>0.265357</td>
+      <td>0.285635</td>
+      <td>0.143886</td>
+      <td>0.259636</td>
+      <td>0.195724</td>
+      <td>0.176947</td>
+      <td>0.162205</td>
+      <td>0.147897</td>
+      <td>0.170488</td>
+      <td>11.00</td>
+      <td>0.012123</td>
+      <td>0.000316</td>
+    </tr>
+    <tr>
+      <th>8581</th>
+      <td>34324.0</td>
+      <td>2.383806</td>
+      <td>0.268580</td>
+      <td>0.151254</td>
+      <td>0.414430</td>
+      <td>0.241540</td>
+      <td>0.244071</td>
+      <td>0.201109</td>
+      <td>0.209611</td>
+      <td>0.097146</td>
+      <td>0.048798</td>
+      <td>0.013239</td>
+      <td>0.035379</td>
+      <td>2.00</td>
+      <td>0.013077</td>
+      <td>0.000615</td>
+    </tr>
+    <tr>
+      <th>8582</th>
+      <td>34328.0</td>
+      <td>1.883626</td>
+      <td>0.089983</td>
+      <td>0.196880</td>
+      <td>0.300523</td>
+      <td>0.239185</td>
+      <td>0.259342</td>
+      <td>0.277586</td>
+      <td>0.206517</td>
+      <td>0.178499</td>
+      <td>0.215561</td>
+      <td>0.067234</td>
+      <td>0.123958</td>
+      <td>13.75</td>
+      <td>0.011466</td>
+      <td>0.000211</td>
+    </tr>
+    <tr>
+      <th>8583</th>
+      <td>34332.0</td>
+      <td>2.599103</td>
+      <td>0.286252</td>
+      <td>-0.014529</td>
+      <td>0.475488</td>
+      <td>0.229446</td>
+      <td>0.188200</td>
+      <td>0.173689</td>
+      <td>0.033262</td>
+      <td>0.138957</td>
+      <td>0.106176</td>
+      <td>0.036859</td>
+      <td>0.082178</td>
+      <td>12.50</td>
+      <td>0.015068</td>
+      <td>0.000891</td>
+    </tr>
+  </tbody>
+</table>
+<p>8584 rows × 16 columns</p>
+</div>
+
+
+
+## Step 3: Detect tremor
+
+The function [`detect_tremor`](https://github.com/biomarkersParkinson/paradigma/blob/main/src/paradigma/pipelines/tremor_pipeline.py#:~:text=detect_tremor) uses a pretrained logistic regression classifier to predict the tremor probability (`pred_tremor_proba`) for each window, based on the MFCCs. Using the prespecified threshold, a tremor label of 0 (no tremor) or 1 (tremor) is assigned (`pred_tremor_logreg`). Furthermore, the detected tremor windows are checked for rest tremor in two ways. First, the frequency of the peak should be between 3-7 Hz. Second, we want to exclude windows with significant arm movements. We consider a window to have significant arm movement if `below_tremor_power` exceeds `config.movement_threshold`. The final tremor label is saved in `pred_tremor_checked`. A label for predicted arm at rest (`pred_arm_at_rest`, which is 1 when at rest and 0 when not at rest) was also saved, to control for the amount of arm movement during the observed time period when aggregating the amount of tremor time in Step 4 (if a person is moving their arm, they cannot have rest tremor).
+
+
+```python
+from importlib.resources import files
+from paradigma.pipelines.tremor_pipeline import detect_tremor
+
+print(f'A threshold of {config.movement_threshold} deg\u00b2/s\u00b2 \
+is used to determine whether the arm is at rest or in stable posture.')
+
+# Load the pre-trained logistic regression classifier
+tremor_detection_classifier_package_filename = 'tremor_detection_clf_package.pkl'
+full_path_to_classifier_package = files('paradigma') / 'assets' / tremor_detection_classifier_package_filename
+
+# Use the logistic regression classifier to detect tremor and check for rest tremor
+df_predictions = detect_tremor(df_features, config, full_path_to_classifier_package)
+
+df_predictions[['time', 'pred_tremor_proba', 'pred_tremor_logreg', 'pred_arm_at_rest', 'pred_tremor_checked']]
+```
+
+    A threshold of 50 deg²/s² is used to determine whether the arm is at rest or in stable posture.
+    
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>pred_tremor_proba</th>
+      <th>pred_tremor_logreg</th>
+      <th>pred_arm_at_rest</th>
+      <th>pred_tremor_checked</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.0</td>
+      <td>0.038968</td>
+      <td>1</td>
+      <td>1</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>4.0</td>
+      <td>0.035365</td>
+      <td>1</td>
+      <td>1</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>8.0</td>
+      <td>0.031255</td>
+      <td>1</td>
+      <td>1</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>12.0</td>
+      <td>0.021106</td>
+      <td>0</td>
+      <td>1</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>16.0</td>
+      <td>0.021078</td>
+      <td>0</td>
+      <td>1</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>8579</th>
+      <td>34316.0</td>
+      <td>0.000296</td>
+      <td>0</td>
+      <td>1</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>8580</th>
+      <td>34320.0</td>
+      <td>0.000089</td>
+      <td>0</td>
+      <td>1</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>8581</th>
+      <td>34324.0</td>
+      <td>0.000023</td>
+      <td>0</td>
+      <td>1</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>8582</th>
+      <td>34328.0</td>
+      <td>0.000053</td>
+      <td>0</td>
+      <td>1</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <th>8583</th>
+      <td>34332.0</td>
+      <td>0.000049</td>
+      <td>0</td>
+      <td>1</td>
+      <td>0</td>
+    </tr>
+  </tbody>
+</table>
+<p>8584 rows × 5 columns</p>
+</div>
+
+
+
+#### Store as TSDF
+The predicted probabilities (and optionally other features) can be stored and loaded in TSDF as demonstrated below. 
+
+
+```python
+import tsdf
+from paradigma.util import write_df_data
+
+# Set 'path_to_data' to the directory where you want to save the data
+metadata_time_store = tsdf.TSDFMetadata(metadata_time.get_plain_tsdf_dict_copy(), path_to_data)
+metadata_values_store = tsdf.TSDFMetadata(metadata_values.get_plain_tsdf_dict_copy(), path_to_data)
+
+# Select the columns to be saved 
+metadata_time_store.channels = ['time']
+metadata_values_store.channels = ['pred_tremor_proba', 'pred_tremor_logreg', 'pred_arm_at_rest', 'pred_tremor_checked']
+
+# Set the units
+metadata_time_store.units = ['Relative seconds']
+metadata_values_store.units = ['Unitless', 'Unitless', 'Unitless', 'Unitless']  
+metadata_time_store.data_type = float
+metadata_values_store.data_type = float
+
+# Set the filenames
+meta_store_filename = f'segment{segment_nr}_meta.json'
+values_store_filename = meta_store_filename.replace('_meta.json', '_values.bin')
+time_store_filename = meta_store_filename.replace('_meta.json', '_time.bin')
+
+metadata_values_store.file_name = values_store_filename
+metadata_time_store.file_name = time_store_filename
+
+write_df_data(metadata_time_store, metadata_values_store, path_to_data, meta_store_filename, df_predictions)
+```
+
+
+```python
+df_predictions, _, _ = load_tsdf_dataframe(path_to_data, prefix=f'segment{segment_nr}')
+df_predictions.head()
+```
+
+## Step 4: Quantify tremor
+
+The tremor power of all predicted tremor windows (where `pred_tremor_checked` is 1) is used for tremor quantification. A datetime column is also added, providing necessary information before aggregating over specified hours in Step 5.
+
+
+```python
+import pandas as pd
+import datetime
+import pytz
+
+df_quantification = df_predictions[['time', 'pred_arm_at_rest', 'pred_tremor_checked','tremor_power']].copy()
+df_quantification.loc[df_predictions['pred_tremor_checked'] == 0, 'tremor_power'] = None # tremor power of non-tremor windows is set to None
+
+# Create datetime column based on the start time of the segment
+start_time = datetime.datetime.strptime(metadata_time.start_iso8601, '%Y-%m-%dT%H:%M:%SZ')
+start_time = start_time.replace(tzinfo=pytz.timezone('UTC')).astimezone(pytz.timezone('CET')) # convert to correct timezone if necessary
+df_quantification['time_dt'] = start_time + pd.to_timedelta(df_quantification['time'], unit="s") 
+df_quantification = df_quantification[['time', 'time_dt', 'pred_arm_at_rest', 'pred_tremor_checked', 'tremor_power']]
+
+df_quantification
+```
+
+
+
+
+<div>
+<style scoped>
+    .dataframe tbody tr th:only-of-type {
+        vertical-align: middle;
+    }
+
+    .dataframe tbody tr th {
+        vertical-align: top;
+    }
+
+    .dataframe thead th {
+        text-align: right;
+    }
+</style>
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>time</th>
+      <th>time_dt</th>
+      <th>pred_arm_at_rest</th>
+      <th>pred_tremor_checked</th>
+      <th>tremor_power</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0.0</td>
+      <td>2019-08-20 12:39:16+02:00</td>
+      <td>1</td>
+      <td>1</td>
+      <td>0.471588</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>4.0</td>
+      <td>2019-08-20 12:39:20+02:00</td>
+      <td>1</td>
+      <td>1</td>
+      <td>0.327252</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>8.0</td>
+      <td>2019-08-20 12:39:24+02:00</td>
+      <td>1</td>
+      <td>0</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>12.0</td>
+      <td>2019-08-20 12:39:28+02:00</td>
+      <td>1</td>
+      <td>0</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>16.0</td>
+      <td>2019-08-20 12:39:32+02:00</td>
+      <td>1</td>
+      <td>0</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>8579</th>
+      <td>34316.0</td>
+      <td>2019-08-20 22:11:12+02:00</td>
+      <td>1</td>
+      <td>0</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>8580</th>
+      <td>34320.0</td>
+      <td>2019-08-20 22:11:16+02:00</td>
+      <td>1</td>
+      <td>0</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>8581</th>
+      <td>34324.0</td>
+      <td>2019-08-20 22:11:20+02:00</td>
+      <td>1</td>
+      <td>0</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>8582</th>
+      <td>34328.0</td>
+      <td>2019-08-20 22:11:24+02:00</td>
+      <td>1</td>
+      <td>0</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>8583</th>
+      <td>34332.0</td>
+      <td>2019-08-20 22:11:28+02:00</td>
+      <td>1</td>
+      <td>0</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>
+<p>8584 rows × 5 columns</p>
+</div>
+
+
+
+### Run steps 1 - 4 for all segments <a id='multiple_segments_cell'></a>
+
+If your data is also stored in multiple segments, you can modify `segments` in the cell below to a list of the filenames of your respective segmented data.
+
+
+```python
+from pathlib import Path
+from importlib.resources import files
+
+from paradigma.util import load_tsdf_dataframe
+from paradigma.config import IMUConfig, TremorConfig
+from paradigma.preprocessing import preprocess_imu_data
+from paradigma.pipelines.tremor_pipeline import extract_tremor_features, detect_tremor
+
+# Set the path to where the prepared data is saved
+path_to_data =  Path('../../example_data')
+path_to_prepared_data = path_to_data / 'imu'
+
+# Load the pre-trained logistic regression classifier
+tremor_detection_classifier_package_filename = 'tremor_detection_clf_package.pkl'
+full_path_to_classifier_package = files('paradigma') / 'assets' / tremor_detection_classifier_package_filename
+
+# Create a list of dataframes to store the quantifications of all segments
+list_df_quantifications = []
+
+segments  = ['0001','0002'] # list with all  available segments
+
+for segment_nr in segments:
+    
+    # Load the data
+    df_data, metadata_time, _ = load_tsdf_dataframe(path_to_prepared_data, prefix='IMU_segment'+segment_nr)
+
+    # 1: Preprocess the data
+    config = IMUConfig()
+    df_preprocessed_data = preprocess_imu_data(df_data, config, sensor='gyroscope', watch_side='left')
+
+    # 2: Extract features
+    config = TremorConfig(step='features')
+    df_features = extract_tremor_features(df_preprocessed_data, config)
+
+    # 3: Detect tremor
+    df_predictions = detect_tremor(df_features, config, full_path_to_classifier_package)
+
+    # 4: Quantify tremor
+    df_quantification = df_predictions[['time', 'pred_arm_at_rest', 'pred_tremor_checked','tremor_power']].copy()
+    df_quantification.loc[df_predictions['pred_tremor_checked'] == 0, 'tremor_power'] = None
+
+    # Create datetime column based on the start time of the segment
+    start_time = datetime.datetime.strptime(metadata_time.start_iso8601, '%Y-%m-%dT%H:%M:%SZ')
+    start_time = start_time.replace(tzinfo=pytz.timezone('UTC')).astimezone(pytz.timezone('CET')) # convert to correct timezone if necessary
+    df_quantification['time_dt'] = start_time + pd.to_timedelta(df_quantification['time'], unit="s") 
+    df_quantification = df_quantification[['time', 'time_dt', 'pred_arm_at_rest', 'pred_tremor_checked', 'tremor_power']]
+
+    # Add the quantifications of the current segment to the list
+    df_quantification['segment_nr'] = segment_nr
+    list_df_quantifications.append(df_quantification)
+
+df_quantification = pd.concat(list_df_quantifications, ignore_index=True)
+```
+
+## Step 5: Compute aggregated tremor measures
+
+The final step is to compute the amount of tremor time and tremor power with the function [`aggregate_tremor`](https://github.com/biomarkersParkinson/paradigma/blob/main/src/paradigma/pipelines/tremor_pipeline.py#:~:text=aggregate_tremor), which aggregates over all windows in the input dataframe. Depending on the size of the input dateframe, you could select the hours and days (both optional) that you want to include in this analysis. In this case we use data collected between 8 am and 10 pm (specified as `select_hours_start` and `select_hours_end`), and days with at least 10 hours of data (`min_hours_per_day`) based on. Based on the selected data, we compute aggregated measures for tremor time and tremor power:
+- Tremor time is calculated as the number of detected tremor windows, as percentage of the number of windows while the arm is at rest or in stable posture (when `below_tremor_power` does not exceed `config.movement_threshold`). This way the tremor time is controlled for the amount of time the arm is at rest or in stable posture, when rest tremor and re-emergent tremor could occur.
+- For tremor power the following aggregates are derived: the mode, median and 90th percentile of tremor power (specified in `config.aggregates_tremor_power`). The median and modal tremor power reflect the typical tremor severity, whereas the 90th percentile reflects the maximal tremor severity within the observed timeframe. The aggregated tremor measures and metadata are stored in a json file.
+
+
+```python
+import pprint
+from paradigma.util import select_hours, select_days
+from paradigma.pipelines.tremor_pipeline import aggregate_tremor
+
+select_hours_start = '08:00' # you can specifiy the hours and minutes here
+select_hours_end = '22:00'
+min_hours_per_day = 10
+
+print(f'Before aggregation we select data collected between {select_hours_start} \
+and {select_hours_end}. We also select days with at least {min_hours_per_day} hours of data.')
+print(f'The following tremor power aggregates are derived: {config.aggregates_tremor_power}.')
+
+# Select the hours that should be included in the analysis
+df_quantification = select_hours(df_quantification, select_hours_start, select_hours_end)
+
+# Remove days with less than the specified minimum amount of hours
+df_quantification = select_days(df_quantification, min_hours_per_day)
+
+# Compute the aggregated measures
+config = TremorConfig()
+d_tremor_aggregates = aggregate_tremor(df = df_quantification, config = config)
+
+pprint.pprint(d_tremor_aggregates)
+```
+
+    Before aggregation we select data collected between 08:00 and 22:00. We also select days with at least 10 hours of data.
+    The following tremor power aggregates are derived: ['mode', 'median', '90p'].
+    {'aggregated_tremor_measures': {'90p_tremor_power': 1.3259483071516063,
+                                    'median_tremor_power': 0.5143985314908104,
+                                    'modal_tremor_power': 0.3,
+                                    'perc_windows_tremor': 19.386769676484793},
+     'metadata': {'nr_valid_days': 1,
+                  'nr_windows_rest': 8284,
+                  'nr_windows_total': 12600}}
+    


### PR DESCRIPTION
## Description

.ipynb pages are not rendered correctly in GitHub Pages (see notes at the bottom of [this page](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage?search-overlay-input=Why+can%27t+github+LFS+be+used+with+github+pages%3F+What+are+alternatives+to+create+static+notebooks+on+github+pages%3F+Would+you+suggest+nbviewer+or+creating+static+html+pages+using+nbconvert%3F&search-overlay-ask-ai=true)). This issue is related to GitHub LFS and only persists on GitHub Pages (not on GitHub itself).

## Changes

I've manually created static markdown files using `nbconvert` (how to do so I documented briefly [here](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage?search-overlay-input=Why+can%27t+github+LFS+be+used+with+github+pages%3F+What+are+alternatives+to+create+static+notebooks+on+github+pages%3F+Would+you+suggest+nbviewer+or+creating+static+html+pages+using+nbconvert%3F&search-overlay-ask-ai=true)).

## Additional Information

The current markdown display of tables is suboptimal, but it functions. This seems to be the easiest solution to this problem, but we can ask Twan later if he knows any other solutions that may be prettier in display.

## Checklist

- [X] Tests passed
- [X] Documentation updated
