### PR TITLE
Bump to v1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "paradigma"
-version = "1.0.0"
+version = "1.0.1"
 description = "ParaDigMa - A toolbox for deriving Parkinson's disease Digital Markers from real-life wrist sensor data"
 authors = [ "Erik Post <erik.post@radboudumc.nl>",
             "Kars Veldkamp <kars.veldkamp@radboudumc.nl>",


### PR DESCRIPTION
## Description

Version in Poetry should be adjusted from v1.0.0 to v1.0.1 to trigger PyPi release. If possible, please confirm today so that release is ready for CPP presentation tomorrow.
