### PR TITLE
Pre-release v1.0.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,11 +87,13 @@ git checkout -b name-of-your-bugfix-or-feature
 4. Make your changes and run the pre-commit hooks:
 
 ```bash
+pip install pre-commit
+pre-commit install
 pre-commit run --all-files
 ```
 
 This ensures code formatting (`black`), import sorting (`isort`), stripping notebook outputs, and other checks.
-This is also automatically done when committing.
+These pre-commit hooks also run for changed and staged files when committing.
 
 5. If contributing to docs, build and serve them locally to verify:
 

--- a/docs/tutorials/pulse_rate_analysis.ipynb
+++ b/docs/tutorials/pulse_rate_analysis.ipynb
@@ -490,7 +490,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "paradigma"
-version = "1.0.3"
+version = "1.0.4"
 description = "ParaDigMa - A toolbox for deriving Parkinson's disease Digital Markers from real-life wrist sensor data"
 authors = [ "Erik Post <erik.post@radboudumc.nl>",
             "Kars Veldkamp <kars.veldkamp@radboudumc.nl>",
@@ -19,8 +19,6 @@ pandas = "^2.1.4"
 scikit-learn = ">=1.3.2,<1.6.1"
 tsdf = "^0.5.2"
 pytype = "^2024.4.11"
-# for the record: pytype was installed directly with pip (in the poetry environment),
-# because poetry didn't handle the install for different CPU architectures
 python-dateutil = "^2.9.0.post0"
 nbconvert = "^7.16.6"
 

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -22,8 +22,9 @@ def main():
         with nb_path.open("r", encoding="utf-8") as f:
             nb = read(f, as_version=4)
 
-        kernel_name = f"python{sys.version_info.major}"
-        client = NotebookClient(nb, timeout=600, kernel_name=kernel_name)
+        client = NotebookClient(
+            nb, timeout=600, kernel_name=f"python{sys.version_info.major}"
+        )
         client.execute(cwd=nb_path.parent)
 
         with nb_path.open("w", encoding="utf-8") as f:


### PR DESCRIPTION
## Description
Pre-release for v1.0.4, including version bump and docs cleanup.

## Changes
* Bump `pyproject.toml` to `v1.0.4`
* Set kernel version to system default: `3.12`

## Checklist

- [x] Tests passed
- [x] Documentation updated
