### PR TITLE
Fix title formatting in paper.md (block scalar to resolve conflict with "parkinson's" single quote usage)

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,5 +1,6 @@
 ---
-title: "ParaDigMa: a Python toolbox for extracting Parkinson's disease digital biomarkers from daily life wrist sensor data"
+title: >-
+    ParaDigMa: a Python toolbox for extracting Parkinson's disease digital biomarkers from daily life wrist sensor data
 tags:
     - Python
 authors:

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'ParaDigMa: a Python toolbox for extracting Parkinson's disease digital biomarkers from daily life wrist sensor data'
+title: "ParaDigMa: a Python toolbox for extracting Parkinson's disease digital biomarkers from daily life wrist sensor data"
 tags:
     - Python
 authors:


### PR DESCRIPTION
The word "parkinson's" in the title closes single quotes, which raises a yaml error. Therefore, the title should be changed to use double quotes or a block scalar (implemented here).
