### PR TITLE
Fix fs dependency tremor pipeline

### DIFF
--- a/src/paradigma/config.py
+++ b/src/paradigma/config.py
@@ -238,7 +238,8 @@ class TremorConfig(IMUConfig):
         self.overlap_fraction: float = 0.8
         self.segment_length_psd_s: float = 3
         self.segment_length_spectrogram_s: float = 2
-        self.spectral_resolution: float = 0.25
+        self.spectral_resolution_psd: float = 0.25
+        self.spectral_resolution_spectrogram: float = 0.5
 
         # PSD based features
         self.fmin_peak_search: float = 1

--- a/src/paradigma/pipelines/tremor_pipeline.py
+++ b/src/paradigma/pipelines/tremor_pipeline.py
@@ -339,9 +339,9 @@ def extract_spectral_domain_features(data: np.ndarray, config) -> pd.DataFrame:
 
     # Compute the power spectral density
     segment_length_n = sampling_frequency * segment_length_psd_s
-    overlap_n = int(segment_length_n * overlap_fraction)
+    overlap_n = int(np.round(segment_length_n * overlap_fraction))
     window = signal.get_window(window_type, segment_length_n, fftbins=False)
-    nfft = int(sampling_frequency / spectral_resolution_psd)
+    nfft = int(np.round(sampling_frequency / spectral_resolution_psd))
 
     freqs, psd = signal.welch(
         x=data,
@@ -357,9 +357,9 @@ def extract_spectral_domain_features(data: np.ndarray, config) -> pd.DataFrame:
 
     # Compute the spectrogram
     segment_length_n = sampling_frequency * segment_length_spectrogram_s
-    overlap_n = int(segment_length_n * overlap_fraction)
+    overlap_n = int(np.round(segment_length_n * overlap_fraction))
     window = signal.get_window(window_type, segment_length_n)
-    nfft = int(sampling_frequency / spectral_resolution_spectrogram)
+    nfft = int(np.round(sampling_frequency / spectral_resolution_spectrogram))
 
     f, t, stft_result = signal.stft(
         x=data,
@@ -377,7 +377,8 @@ def extract_spectral_domain_features(data: np.ndarray, config) -> pd.DataFrame:
     total_psd = compute_total_power(psd)
     total_spectrogram = np.sum(
         np.abs(stft_result) * 100, axis=2
-    )  # scaling factor of 100 to match with previous Matlab code
+    )  # scaling factor of 100 to match with previous Matlab code which was
+    # developed on a 100 Hz sampling frequency and 2 second window length
 
     # Compute the MFCC's
     config.mfcc_low_frequency = config.fmin_mfcc

--- a/src/paradigma/pipelines/tremor_pipeline.py
+++ b/src/paradigma/pipelines/tremor_pipeline.py
@@ -333,14 +333,15 @@ def extract_spectral_domain_features(data: np.ndarray, config) -> pd.DataFrame:
     segment_length_psd_s = config.segment_length_psd_s
     segment_length_spectrogram_s = config.segment_length_spectrogram_s
     overlap_fraction = config.overlap_fraction
-    spectral_resolution = config.spectral_resolution
+    spectral_resolution_psd = config.spectral_resolution_psd
+    spectral_resolution_spectrogram = config.spectral_resolution_spectrogram
     window_type = "hann"
 
     # Compute the power spectral density
     segment_length_n = sampling_frequency * segment_length_psd_s
-    overlap_n = segment_length_n * overlap_fraction
+    overlap_n = int(segment_length_n * overlap_fraction)
     window = signal.get_window(window_type, segment_length_n, fftbins=False)
-    nfft = sampling_frequency / spectral_resolution
+    nfft = int(sampling_frequency / spectral_resolution_psd)
 
     freqs, psd = signal.welch(
         x=data,
@@ -356,9 +357,9 @@ def extract_spectral_domain_features(data: np.ndarray, config) -> pd.DataFrame:
 
     # Compute the spectrogram
     segment_length_n = sampling_frequency * segment_length_spectrogram_s
-    overlap_n = segment_length_n * overlap_fraction
+    overlap_n = int(segment_length_n * overlap_fraction)
     window = signal.get_window(window_type, segment_length_n)
-    nfft = int(sampling_frequency / 0.5)
+    nfft = int(sampling_frequency / spectral_resolution_spectrogram)
 
     f, t, stft_result = signal.stft(
         x=data,
@@ -374,7 +375,9 @@ def extract_spectral_domain_features(data: np.ndarray, config) -> pd.DataFrame:
     # Compute total power in the PSD and the total spectrogram (summed over
     # the three axes)
     total_psd = compute_total_power(psd)
-    total_spectrogram = np.sum(np.abs(stft_result) * (segment_length_n / 2), axis=2)
+    total_spectrogram = np.sum(
+        np.abs(stft_result) * 100, axis=2
+    )  # scaling factor of 100 to match with previous Matlab code
 
     # Compute the MFCC's
     config.mfcc_low_frequency = config.fmin_mfcc
@@ -405,7 +408,7 @@ def extract_spectral_domain_features(data: np.ndarray, config) -> pd.DataFrame:
         config.fmin_below_rest_tremor,
         config.fmax_below_rest_tremor,
         include_max=False,
-        spectral_resolution=config.spectral_resolution,
+        spectral_resolution=config.spectral_resolution_psd,
         cumulative_sum_method="sum",
     )
     feature_dict[DataColumns.TREMOR_POWER] = extract_tremor_power(
@@ -502,7 +505,7 @@ def run_tremor_pipeline(
 
     if "preprocessing" in store_intermediate:
         preprocessing_dir = output_dir / "preprocessing"
-        preprocessing_dir.mkdir(exist_ok=True)
+        preprocessing_dir.mkdir(parents=True, exist_ok=True)
         df_preprocessed.to_parquet(preprocessing_dir / "tremor_preprocessed.parquet")
         active_logger.info(f"Saved preprocessed data to {preprocessing_dir}")
 
@@ -523,7 +526,7 @@ def run_tremor_pipeline(
 
     if "classification" in store_intermediate:
         classification_dir = output_dir / "classification"
-        classification_dir.mkdir(exist_ok=True)
+        classification_dir.mkdir(parents=True, exist_ok=True)
         df_predictions.to_parquet(classification_dir / "tremor_predictions.parquet")
         active_logger.info(f"Saved tremor predictions to {classification_dir}")
 
@@ -562,7 +565,7 @@ def run_tremor_pipeline(
 
     if "quantification" in store_intermediate:
         quantification_dir = output_dir / "quantification"
-        quantification_dir.mkdir(exist_ok=True)
+        quantification_dir.mkdir(parents=True, exist_ok=True)
         df_quantification.to_parquet(
             quantification_dir / "tremor_quantification.parquet"
         )

--- a/src/paradigma/pipelines/tremor_pipeline.py
+++ b/src/paradigma/pipelines/tremor_pipeline.py
@@ -358,6 +358,7 @@ def extract_spectral_domain_features(data: np.ndarray, config) -> pd.DataFrame:
     segment_length_n = sampling_frequency * segment_length_spectrogram_s
     overlap_n = segment_length_n * overlap_fraction
     window = signal.get_window(window_type, segment_length_n)
+    nfft = int(sampling_frequency / 0.5)
 
     f, t, stft_result = signal.stft(
         x=data,
@@ -365,6 +366,7 @@ def extract_spectral_domain_features(data: np.ndarray, config) -> pd.DataFrame:
         window=window,
         nperseg=segment_length_n,
         noverlap=overlap_n,
+        nfft=nfft,
         boundary=None,
         axis=1,
     )
@@ -372,7 +374,7 @@ def extract_spectral_domain_features(data: np.ndarray, config) -> pd.DataFrame:
     # Compute total power in the PSD and the total spectrogram (summed over
     # the three axes)
     total_psd = compute_total_power(psd)
-    total_spectrogram = np.sum(np.abs(stft_result) * sampling_frequency, axis=2)
+    total_spectrogram = np.sum(np.abs(stft_result) * (segment_length_n / 2), axis=2)
 
     # Compute the MFCC's
     config.mfcc_low_frequency = config.fmin_mfcc


### PR DESCRIPTION
## Description

The tremor pipeline worked well for gyroscope signals sampled at 100Hz, but did not for signals sampled at lower frequencies. 
With these changes the pipeline works well for sampling frequencies as low as 64Hz. 

## Changes

- Computation of the spectrogram was adjusted to make it independent of the sampling frequency used.
- Also a bug related to storing intermediate results was fixed.

## Additional Information

The changes were tested for one week of data of 8 patients. Weekly tremor measures were similar for 100Hz and 64Hz downsampled signals.  

## Checklist

- [x] Tests passed
- [x] Documentation updated
