### PR TITLE
Add paradigma team as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require team's approval for everything targeting release
+* @biomarkersparkinson/paradigma


### PR DESCRIPTION
## Description
External users of Paradigma are currently also able to approve pull requests, adding vulnerability to the codebase. 

## Changes
1. Add the _paradigma_ team to the _biomarkersParkinson_ project space, and added myself, Kars, Nienke and Margherita as members (this is no code change);
2. Add _CODEOWNERS_ file to the _.github_ folder that marks the _paradigma_ team members as code owners.

## Additional info
I have changed the branch protection rules to require a code owner to approve PRs for both the _main_ and _release_ branch.